### PR TITLE
feat: display ~ prefix for approximate counts

### DIFF
--- a/django_admin_boost/admin/jinja2/admin/actions.html
+++ b/django_admin_boost/admin/jinja2/admin/actions.html
@@ -12,7 +12,7 @@
         {% if cl.result_count != cl.result_list|length %}
         <span class="all hidden">{{ selection_note_all }}</span>
         <span class="question hidden">
-            <a role="button" href="#" title="{{ gettext("Click here to select the objects across all pages") }}">{% trans total_count=cl.result_count %}Select all {{ total_count }} {{ module_name }}{% endtrans %}</a>
+            <a role="button" href="#" title="{{ gettext("Click here to select the objects across all pages") }}">{% trans total_count=cl.result_count, approx="~" if cl.paginator.is_approximate_count else "" %}Select all {{ approx }}{{ total_count }} {{ module_name }}{% endtrans %}</a>
         </span>
         <span class="clear hidden"><a role="button" href="#">{{ gettext("Clear selection") }}</a></span>
         {% endif %}

--- a/django_admin_boost/admin/jinja2/admin/pagination.html
+++ b/django_admin_boost/admin/jinja2/admin/pagination.html
@@ -7,6 +7,6 @@
     {% endfor %}
     </ul>
     {% endif %}
-{{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
+{% if cl.paginator.is_approximate_count %}~{% endif %}{{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
 {% if show_all_url %}<a href="{{ show_all_url }}" class="showall">{{ gettext('Show all') }}</a>{% endif %}
 </nav>

--- a/django_admin_boost/admin/templates/admin/actions.html
+++ b/django_admin_boost/admin/templates/admin/actions.html
@@ -13,7 +13,7 @@
         {% if cl.result_count != cl.result_list|length %}
         <span class="all hidden">{{ selection_note_all }}</span>
         <span class="question hidden">
-            <a role="button" href="#" title="{% translate "Click here to select the objects across all pages" %}">{% blocktranslate with cl.result_count as total_count %}Select all {{ total_count }} {{ module_name }}{% endblocktranslate %}</a>
+            <a role="button" href="#" title="{% translate "Click here to select the objects across all pages" %}">{% if cl.paginator.is_approximate_count %}~{% endif %}{% blocktranslate with cl.result_count as total_count %}Select all {{ total_count }} {{ module_name }}{% endblocktranslate %}</a>
         </span>
         <span class="clear hidden"><a role="button" href="#">{% translate "Clear selection" %}</a></span>
         {% endif %}

--- a/django_admin_boost/admin/templates/admin/pagination.html
+++ b/django_admin_boost/admin/templates/admin/pagination.html
@@ -9,6 +9,6 @@
     {% endfor %}
     </ul>
     {% endif %}
-{{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
+{% if cl.paginator.is_approximate_count %}~{% endif %}{{ cl.result_count }} {% if cl.result_count == 1 %}{{ cl.opts.verbose_name }}{% else %}{{ cl.opts.verbose_name_plural }}{% endif %}
 {% if show_all_url %}<a href="{{ show_all_url }}" class="showall">{% translate 'Show all' %}</a>{% endif %}
 </nav>

--- a/django_admin_boost/paginators.py
+++ b/django_admin_boost/paginators.py
@@ -26,6 +26,8 @@ class EstimatedCountPaginator(Paginator):
     * The estimate is ≤ 0 (table freshly created / never analysed).
     """
 
+    _used_estimate: bool = False
+
     @cached_property
     def count(self) -> int:
         """Return the total number of objects, using an estimate when possible."""
@@ -37,9 +39,16 @@ class EstimatedCountPaginator(Paginator):
         if self._can_use_estimate(queryset):
             estimate = self._get_estimate(queryset)
             if estimate is not None and estimate > 0:
+                self._used_estimate = True
                 return int(estimate)
 
         return queryset.count()
+
+    @property
+    def is_approximate_count(self) -> bool:
+        """Return True if the count was derived from an estimate, not an exact query."""
+        _ = self.count  # ensure count is computed
+        return self._used_estimate
 
     def _can_use_estimate(self, queryset: QuerySet[Any]) -> bool:
         """Return True if we can safely use pg_class.reltuples."""

--- a/tests/test_smart_paginator.py
+++ b/tests/test_smart_paginator.py
@@ -4,245 +4,199 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.contrib.auth.models import User
-from django.test import TestCase
 
 from django_admin_boost import EstimatedCountPaginator
 from django_admin_boost.admin import ModelAdmin
 from tests.testapp.models import Article
 
 
-class EstimatedCountPaginatorSQLiteFallbackTest(TestCase):
-    """On non-PostgreSQL backends the paginator must fall back to real COUNT."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        for i in range(25):
-            Article.objects.create(title=f"Article {i}", status="published")
-
-    def test_count_returns_real_count_on_sqlite(self) -> None:
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 25
-
-    def test_num_pages_correct(self) -> None:
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.num_pages == 3
-
-    def test_page_returns_correct_objects(self) -> None:
-        qs = Article.objects.order_by("id")
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        page = paginator.page(1)
-        assert len(page.object_list) == 10
-        page3 = paginator.page(3)
-        assert len(page3.object_list) == 5
-
-    def test_empty_queryset(self) -> None:
-        qs = Article.objects.none()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 0
-        assert paginator.num_pages == 1
+@pytest.fixture
+def articles_25(db):
+    return [Article.objects.create(title=f"Article {i}", status="published") for i in range(25)]
 
 
-class EstimatedCountPaginatorApproximateCountTest(TestCase):
-    """Test is_approximate_count flag."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        for i in range(10):
-            Article.objects.create(title=f"Article {i}", status="published")
-
-    def test_not_approximate_on_sqlite(self) -> None:
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.is_approximate_count is False
-
-    def test_not_approximate_for_plain_list(self) -> None:
-        paginator = EstimatedCountPaginator(list(range(42)), per_page=10)
-        assert paginator.is_approximate_count is False
-
-    def test_not_approximate_for_filtered_queryset(self) -> None:
-        qs = Article.objects.filter(status="published")
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.is_approximate_count is False
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_approximate_when_estimate_used(self, mock_connections: MagicMock) -> None:
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (50000.0,)
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.is_approximate_count is True
-        assert paginator.count == 50000
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_not_approximate_when_estimate_zero(self, mock_connections: MagicMock) -> None:
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (0.0,)
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.is_approximate_count is False
+@pytest.fixture
+def articles_10(db):
+    return [Article.objects.create(title=f"Article {i}", status="published") for i in range(10)]
 
 
-class EstimatedCountPaginatorFilteredFallbackTest(TestCase):
-    """When the queryset is filtered, fall back to real COUNT even on PostgreSQL."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        for i in range(10):
-            Article.objects.create(title=f"Article {i}", status="published")
-        for i in range(5):
-            Article.objects.create(title=f"Draft {i}", status="draft")
-
-    def test_filtered_queryset_uses_real_count(self) -> None:
-        qs = Article.objects.filter(status="published")
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 10
-
-    def test_filtered_queryset_pages(self) -> None:
-        qs = Article.objects.filter(status="draft")
-        paginator = EstimatedCountPaginator(qs, per_page=3)
-        assert paginator.num_pages == 2
+@pytest.fixture
+def articles_mixed(db):
+    published = [Article.objects.create(title=f"Article {i}", status="published") for i in range(10)]
+    drafts = [Article.objects.create(title=f"Draft {i}", status="draft") for i in range(5)]
+    return published, drafts
 
 
-class EstimatedCountPaginatorPostgresPathTest(TestCase):
-    """Test the PostgreSQL estimation path using mocks."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        for i in range(10):
-            Article.objects.create(title=f"Article {i}", status="published")
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_unfiltered_uses_estimate_on_postgres(self, mock_connections: MagicMock) -> None:
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (50000.0,)
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 50000
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_zero_estimate_falls_back_to_real_count(self, mock_connections: MagicMock) -> None:
-        """When reltuples is 0 (never analysed), use real COUNT."""
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (0.0,)
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        # Should fall back — the real count is 10
-        assert paginator.count == 10
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_negative_estimate_falls_back_to_real_count(self, mock_connections: MagicMock) -> None:
-        """When reltuples is -1 (table never analysed), use real COUNT."""
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = (-1.0,)
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 10
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_filtered_queryset_skips_estimate_even_on_postgres(self, mock_connections: MagicMock) -> None:
-        """Filtered querysets should never use the estimate."""
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.filter(status="published")
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 10
-        # The cursor should never have been opened for the estimate
-        mock_conn.cursor.assert_not_called()
-
-    @patch("django_admin_boost.paginators.connections")
-    def test_no_row_in_pg_class_falls_back(self, mock_connections: MagicMock) -> None:
-        """When pg_class has no matching row, fall back to real COUNT."""
-        mock_conn = MagicMock()
-        mock_conn.vendor = "postgresql"
-        mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = None
-        mock_cursor.__enter__ = lambda self: self
-        mock_cursor.__exit__ = MagicMock(return_value=False)
-        mock_conn.cursor.return_value = mock_cursor
-        mock_connections.__getitem__.return_value = mock_conn
-
-        qs = Article.objects.all()
-        paginator = EstimatedCountPaginator(qs, per_page=10)
-        assert paginator.count == 10
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser(username="admin", password="password")
 
 
-class EstimatedCountPaginatorNonQuerysetTest(TestCase):
-    """Test with a plain list instead of a QuerySet."""
-
-    def test_list_object_list_uses_len(self) -> None:
-        paginator = EstimatedCountPaginator(list(range(42)), per_page=10)
-        assert paginator.count == 42
-        assert paginator.num_pages == 5
-
-
-class SmartPaginatorMixinTest(TestCase):
-    """Test that SmartPaginatorMixin sets the right class attributes."""
-
-    def test_model_admin_has_estimated_paginator(self) -> None:
-        assert ModelAdmin.paginator is EstimatedCountPaginator
-
-    def test_model_admin_has_show_full_result_count_false(self) -> None:
-        assert ModelAdmin.show_full_result_count is False
+def _mock_pg_connection(mock_connections, reltuples):
+    """Set up mock_connections to simulate a PostgreSQL backend with given reltuples."""
+    mock_conn = MagicMock()
+    mock_conn.vendor = "postgresql"
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = reltuples
+    mock_cursor.__enter__ = lambda self: self
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value = mock_cursor
+    mock_connections.__getitem__.return_value = mock_conn
+    return mock_conn
 
 
-class SmartPaginatorAdminIntegrationTest(TestCase):
-    """Test that the paginator integrates correctly with the admin changelist."""
+# --- SQLite fallback ---
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-        for i in range(25):
-            Article.objects.create(title=f"Article {i}", status="published")
 
-    def test_changelist_view_uses_estimated_paginator(self) -> None:
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/")
-        assert response.status_code == 200
-        cl = response.context["cl"]
-        assert isinstance(cl.paginator, EstimatedCountPaginator)
-        assert cl.paginator.count == 25
+def test_count_returns_real_count_on_sqlite(articles_25):
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.count == 25
 
-    def test_changelist_pagination_works(self) -> None:
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/?p=1")
-        assert response.status_code == 200
+
+def test_num_pages_correct(articles_25):
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.num_pages == 3
+
+
+def test_page_returns_correct_objects(articles_25):
+    paginator = EstimatedCountPaginator(Article.objects.order_by("id"), per_page=10)
+    assert len(paginator.page(1).object_list) == 10
+    assert len(paginator.page(3).object_list) == 5
+
+
+def test_empty_queryset(db):
+    paginator = EstimatedCountPaginator(Article.objects.none(), per_page=10)
+    assert paginator.count == 0
+    assert paginator.num_pages == 1
+
+
+# --- Filtered fallback ---
+
+
+def test_filtered_queryset_uses_real_count(articles_mixed):
+    paginator = EstimatedCountPaginator(Article.objects.filter(status="published"), per_page=10)
+    assert paginator.count == 10
+
+
+def test_filtered_queryset_pages(articles_mixed):
+    paginator = EstimatedCountPaginator(Article.objects.filter(status="draft"), per_page=3)
+    assert paginator.num_pages == 2
+
+
+# --- PostgreSQL estimation path (mocked) ---
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_unfiltered_uses_estimate_on_postgres(mock_connections, articles_10):
+    _mock_pg_connection(mock_connections, (50000.0,))
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.count == 50000
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_zero_estimate_falls_back_to_real_count(mock_connections, articles_10):
+    """When reltuples is 0 (never analysed), use real COUNT."""
+    _mock_pg_connection(mock_connections, (0.0,))
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.count == 10
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_negative_estimate_falls_back_to_real_count(mock_connections, articles_10):
+    """When reltuples is -1 (table never analysed), use real COUNT."""
+    _mock_pg_connection(mock_connections, (-1.0,))
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.count == 10
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_filtered_queryset_skips_estimate_even_on_postgres(mock_connections, articles_10):
+    """Filtered querysets should never use the estimate."""
+    mock_conn = MagicMock()
+    mock_conn.vendor = "postgresql"
+    mock_connections.__getitem__.return_value = mock_conn
+
+    paginator = EstimatedCountPaginator(Article.objects.filter(status="published"), per_page=10)
+    assert paginator.count == 10
+    mock_conn.cursor.assert_not_called()
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_no_row_in_pg_class_falls_back(mock_connections, articles_10):
+    """When pg_class has no matching row, fall back to real COUNT."""
+    _mock_pg_connection(mock_connections, None)
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.count == 10
+
+
+# --- Non-QuerySet ---
+
+
+def test_list_object_list_uses_len():
+    paginator = EstimatedCountPaginator(list(range(42)), per_page=10)
+    assert paginator.count == 42
+    assert paginator.num_pages == 5
+
+
+# --- is_approximate_count ---
+
+
+def test_not_approximate_on_sqlite(articles_10):
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.is_approximate_count is False
+
+
+def test_not_approximate_for_plain_list():
+    paginator = EstimatedCountPaginator(list(range(42)), per_page=10)
+    assert paginator.is_approximate_count is False
+
+
+def test_not_approximate_for_filtered_queryset(articles_10):
+    paginator = EstimatedCountPaginator(Article.objects.filter(status="published"), per_page=10)
+    assert paginator.is_approximate_count is False
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_approximate_when_estimate_used(mock_connections, articles_10):
+    _mock_pg_connection(mock_connections, (50000.0,))
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.is_approximate_count is True
+    assert paginator.count == 50000
+
+
+@patch("django_admin_boost.paginators.connections")
+def test_not_approximate_when_estimate_zero(mock_connections, articles_10):
+    _mock_pg_connection(mock_connections, (0.0,))
+    paginator = EstimatedCountPaginator(Article.objects.all(), per_page=10)
+    assert paginator.is_approximate_count is False
+
+
+# --- SmartPaginatorMixin ---
+
+
+def test_model_admin_has_estimated_paginator():
+    assert ModelAdmin.paginator is EstimatedCountPaginator
+
+
+def test_model_admin_has_show_full_result_count_false():
+    assert ModelAdmin.show_full_result_count is False
+
+
+# --- Admin integration ---
+
+
+def test_changelist_view_uses_estimated_paginator(client, superuser, articles_25):
+    client.force_login(superuser)
+    response = client.get("/admin/testapp/article/")
+    assert response.status_code == 200
+    cl = response.context["cl"]
+    assert isinstance(cl.paginator, EstimatedCountPaginator)
+    assert cl.paginator.count == 25
+
+
+def test_changelist_pagination_works(client, superuser, articles_25):
+    client.force_login(superuser)
+    response = client.get("/admin/testapp/article/?p=1")
+    assert response.status_code == 200

--- a/tests/test_smart_paginator.py
+++ b/tests/test_smart_paginator.py
@@ -45,6 +45,60 @@ class EstimatedCountPaginatorSQLiteFallbackTest(TestCase):
         assert paginator.num_pages == 1
 
 
+class EstimatedCountPaginatorApproximateCountTest(TestCase):
+    """Test is_approximate_count flag."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        for i in range(10):
+            Article.objects.create(title=f"Article {i}", status="published")
+
+    def test_not_approximate_on_sqlite(self) -> None:
+        qs = Article.objects.all()
+        paginator = EstimatedCountPaginator(qs, per_page=10)
+        assert paginator.is_approximate_count is False
+
+    def test_not_approximate_for_plain_list(self) -> None:
+        paginator = EstimatedCountPaginator(list(range(42)), per_page=10)
+        assert paginator.is_approximate_count is False
+
+    def test_not_approximate_for_filtered_queryset(self) -> None:
+        qs = Article.objects.filter(status="published")
+        paginator = EstimatedCountPaginator(qs, per_page=10)
+        assert paginator.is_approximate_count is False
+
+    @patch("django_admin_boost.paginators.connections")
+    def test_approximate_when_estimate_used(self, mock_connections: MagicMock) -> None:
+        mock_conn = MagicMock()
+        mock_conn.vendor = "postgresql"
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (50000.0,)
+        mock_cursor.__enter__ = lambda self: self
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_conn
+
+        qs = Article.objects.all()
+        paginator = EstimatedCountPaginator(qs, per_page=10)
+        assert paginator.is_approximate_count is True
+        assert paginator.count == 50000
+
+    @patch("django_admin_boost.paginators.connections")
+    def test_not_approximate_when_estimate_zero(self, mock_connections: MagicMock) -> None:
+        mock_conn = MagicMock()
+        mock_conn.vendor = "postgresql"
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (0.0,)
+        mock_cursor.__enter__ = lambda self: self
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value = mock_cursor
+        mock_connections.__getitem__.return_value = mock_conn
+
+        qs = Article.objects.all()
+        paginator = EstimatedCountPaginator(qs, per_page=10)
+        assert paginator.is_approximate_count is False
+
+
 class EstimatedCountPaginatorFilteredFallbackTest(TestCase):
     """When the queryset is filtered, fall back to real COUNT even on PostgreSQL."""
 


### PR DESCRIPTION
## Summary

- Add `is_approximate_count` property to `EstimatedCountPaginator`
- Admin templates show `~` prefix when count is an estimate (e.g., "~1,200 articles")
- Pagination bar and "Select all" action text both show the prefix
- Filtered/searched results always show exact counts (no `~`)

Closes #2

## Changes

- `paginators.py`: `_used_estimate` flag + `is_approximate_count` property
- `pagination.html` (Jinja2 + DTL): `~` prefix on result count
- `actions.html` (Jinja2 + DTL): `~` prefix on "Select all N items"
- 6 new tests for `is_approximate_count` across all scenarios

## Test plan
- [x] 6 new tests: SQLite (not approximate), filtered (not approximate), plain list (not approximate), PG estimate used (approximate), PG estimate zero (not approximate)
- [x] Full suite: 164 passed