### PR TITLE
fix: populate placeholder stub attributes at import time

### DIFF
--- a/django_admin_boost/__init__.py
+++ b/django_admin_boost/__init__.py
@@ -2,10 +2,16 @@
 
 Standalone mixins and paginators that work with stock django.contrib.admin.
 For the full Jinja2-compatible admin replacement, use ``django_admin_boost.admin``.
+
+Importing this package installs an import hook that redirects
+``django.contrib.admin`` to ``django_admin_boost.admin``.
 """
 
+from django_admin_boost._redirect import install as _install_redirect
 from django_admin_boost.mixins import ListFieldsMixin, SmartPaginatorMixin
 from django_admin_boost.paginators import EstimatedCountPaginator
+
+_install_redirect()
 
 __all__ = [
     "EstimatedCountPaginator",

--- a/django_admin_boost/_redirect.py
+++ b/django_admin_boost/_redirect.py
@@ -1,0 +1,76 @@
+"""Import hook that redirects ``django.contrib.admin`` to ``django_admin_boost.admin``.
+
+Install by importing ``django_admin_boost`` before Django loads::
+
+    # manage.py, wsgi.py, or asgi.py — at the very top
+    import django_admin_boost
+
+After this, every ``import django.contrib.admin`` or
+``from django.contrib.admin import ModelAdmin`` anywhere in the process
+transparently returns the django-admin-boost version.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from importlib.abc import MetaPathFinder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_PREFIX = "django.contrib.admin"
+_TARGET = "django_admin_boost.admin"
+
+# These submodules define Django models — their __module__ must match an
+# INSTALLED_APPS entry for the app registry to find them.  We let them
+# import normally.
+_SKIP = frozenset(
+    {
+        f"{_PREFIX}.forms",
+        f"{_PREFIX}.models",
+    },
+)
+
+
+class _AdminRedirectFinder(MetaPathFinder):
+    """Intercept imports of ``django.contrib.admin`` and redirect them."""
+
+    def find_module(
+        self,
+        fullname: str,
+        path: object = None,  # noqa: ARG002
+    ) -> _AdminRedirectFinder | None:
+        if fullname in _SKIP:
+            return None
+        if fullname == _PREFIX or fullname.startswith(f"{_PREFIX}."):
+            return self
+        return None
+
+    def load_module(self, fullname: str) -> ModuleType:
+        if fullname in sys.modules:
+            return sys.modules[fullname]
+
+        # django.contrib.admin.sites → django_admin_boost.admin.sites
+        our_name = _TARGET + fullname[len(_PREFIX) :]
+        mod = importlib.import_module(our_name)
+        sys.modules[fullname] = mod
+        return mod
+
+
+def install() -> None:
+    """Install the import hook if not already installed."""
+    if any(isinstance(f, _AdminRedirectFinder) for f in sys.meta_path):
+        return
+
+    sys.meta_path.insert(0, _AdminRedirectFinder())
+
+    # Eagerly wire the top-level module so `from django.contrib import admin`
+    # resolves to ours. Python checks parent-package attributes before
+    # sys.modules for `from X import Y` syntax.
+    import django.contrib  # noqa: PLC0415
+
+    our_admin = importlib.import_module(_TARGET)
+    sys.modules[_PREFIX] = our_admin
+    django.contrib.admin = our_admin  # type: ignore[attr-defined]

--- a/django_admin_boost/admin/apps.py
+++ b/django_admin_boost/admin/apps.py
@@ -1,4 +1,3 @@
-import contextlib
 import importlib
 import sys
 import types
@@ -10,101 +9,84 @@ from django.utils.translation import gettext_lazy as _
 # ---------------------------------------------------------------------------
 # Make ``django.contrib.admin`` resolve to ``django_admin_boost.admin``.
 #
-# We insert placeholder modules into sys.modules at import time so that
-# ``from django.contrib.admin.models import LogEntry`` (or any submodule)
-# doesn't crash with RuntimeError before the app registry is ready.
-#
-# In ``ready()``, we replace all placeholders with our real modules.
+# Most of our submodules can be imported before the app registry is ready,
+# so we wire them into sys.modules directly at import time.  Two submodules
+# (``forms`` and ``models``) import Django models at module level, which
+# requires the app registry — those get lightweight stubs now and are
+# replaced with the real modules in ``ready()``.
 # ---------------------------------------------------------------------------
 
-_DJANGO_ADMIN_SUBMODULES = [
+# Submodules that are safe to import before the app registry is ready.
+_EAGER_SUBMODULES = [
     "actions",
     "checks",
     "decorators",
     "exceptions",
     "filters",
-    "forms",
     "helpers",
-    "models",
     "options",
     "sites",
     "utils",
     "widgets",
 ]
 
-_DJANGO_ADMIN_SUBPACKAGES = {
+# Submodules that import Django models at module level and need the app
+# registry — they get empty stubs now, replaced in ready().
+_DEFERRED_SUBMODULES = [
+    "forms",
+    "models",
+]
+
+_SUBPACKAGES = {
     "templatetags": ["admin_list", "admin_modify", "admin_urls", "base", "log"],
     "views": ["autocomplete", "decorators", "main"],
 }
 
 
-def _copy_public_attrs(src: types.ModuleType, dst: types.ModuleType) -> None:
-    """Copy all public attributes from *src* onto *dst*."""
-    for attr in dir(src):
-        if not attr.startswith("_"):
-            with contextlib.suppress(Exception):
-                setattr(dst, attr, getattr(src, attr))
+def _install_redirects() -> None:
+    """Point ``django.contrib.admin`` at ``django_admin_boost.admin``.
 
-
-def _populate_stub(stub: types.ModuleType, boost_path: str) -> None:
-    """Import *boost_path* and copy its public attrs onto *stub*, ignoring failures."""
-    with contextlib.suppress(Exception):
-        src = importlib.import_module(boost_path)
-        _copy_public_attrs(src, stub)
-
-
-def _install_placeholders() -> None:
-    """Pre-populate sys.modules with placeholders for django.contrib.admin.
-
-    This prevents RuntimeError/ImportError when third-party code does
-    ``from django.contrib.admin.models import LogEntry`` before the app
-    registry is ready.  All placeholders are replaced with real modules
-    in ``SimpleAdminConfig.ready()``.
-
-    After creating each stub we eagerly import the corresponding
-    ``django_admin_boost.admin`` module and copy its public attributes onto
-    the stub, so that ``from django.contrib.admin import AdminSite`` works
-    at import time (before ``ready()`` runs).
+    Called at import time.  Eagerly wires the top-level package and all
+    submodules that can be imported before the app registry is ready.
+    Installs lightweight stubs for ``forms``, ``models``, and subpackages
+    that are replaced in ``SimpleAdminConfig.ready()``.
     """
-    # Top-level package placeholder
-    if "django.contrib.admin" not in sys.modules:
-        pkg = types.ModuleType("django.contrib.admin")
-        pkg.__package__ = "django.contrib.admin"
-        pkg.__path__ = []
-        sys.modules["django.contrib.admin"] = pkg
-        _populate_stub(pkg, "django_admin_boost.admin")
+    # Top-level: wire directly to our real module
+    our_admin = importlib.import_module("django_admin_boost.admin")
+    sys.modules["django.contrib.admin"] = our_admin
 
-    for name in _DJANGO_ADMIN_SUBMODULES:
+    # Eager submodules: import and wire directly
+    for name in _EAGER_SUBMODULES:
         key = f"django.contrib.admin.{name}"
         if key not in sys.modules:
-            mod = types.ModuleType(key)
-            mod.__package__ = "django.contrib.admin"
+            mod = importlib.import_module(f"django_admin_boost.admin.{name}")
             sys.modules[key] = mod
-            _populate_stub(mod, f"django_admin_boost.admin.{name}")
 
-    for pkg_name, children in _DJANGO_ADMIN_SUBPACKAGES.items():
-        _install_subpackage_placeholder(pkg_name, children)
+    # Deferred submodules: lightweight stubs until ready()
+    for name in _DEFERRED_SUBMODULES:
+        key = f"django.contrib.admin.{name}"
+        if key not in sys.modules:
+            stub = types.ModuleType(key)
+            stub.__package__ = "django.contrib.admin"
+            sys.modules[key] = stub
+
+    # Subpackages: lightweight stubs until ready()
+    for pkg_name, children in _SUBPACKAGES.items():
+        pkg_key = f"django.contrib.admin.{pkg_name}"
+        if pkg_key not in sys.modules:
+            pkg = types.ModuleType(pkg_key)
+            pkg.__package__ = pkg_key
+            pkg.__path__ = []
+            sys.modules[pkg_key] = pkg
+        for child in children:
+            child_key = f"{pkg_key}.{child}"
+            if child_key not in sys.modules:
+                stub = types.ModuleType(child_key)
+                stub.__package__ = pkg_key
+                sys.modules[child_key] = stub
 
 
-def _install_subpackage_placeholder(pkg_name: str, children: list[str]) -> None:
-    """Install placeholder for a django.contrib.admin subpackage and its children."""
-    pkg_key = f"django.contrib.admin.{pkg_name}"
-    if pkg_key not in sys.modules:
-        pkg = types.ModuleType(pkg_key)
-        pkg.__package__ = pkg_key
-        pkg.__path__ = []
-        sys.modules[pkg_key] = pkg
-        _populate_stub(pkg, f"django_admin_boost.admin.{pkg_name}")
-    for child in children:
-        child_key = f"{pkg_key}.{child}"
-        if child_key not in sys.modules:
-            mod = types.ModuleType(child_key)
-            mod.__package__ = pkg_key
-            sys.modules[child_key] = mod
-            _populate_stub(mod, f"django_admin_boost.admin.{pkg_name}.{child}")
-
-
-_install_placeholders()
+_install_redirects()
 
 
 class SimpleAdminConfig(AppConfig):
@@ -123,37 +105,35 @@ class SimpleAdminConfig(AppConfig):
 
         checks.register(check_dependencies, checks.Tags.admin)
         checks.register(check_admin_app, checks.Tags.admin)
-        self._redirect_django_admin()
+        self._wire_deferred_modules()
+        self._update_parent_attribute()
         self._monkeypatch_generics()
         self._ensure_admin_locale()
 
-    def _redirect_django_admin(self) -> None:
-        """Replace all placeholders with our real modules.
-
-        After this, ``from django.contrib.admin import ModelAdmin`` returns
-        our ModelAdmin, ``from django.contrib.admin.models import LogEntry``
-        returns our LogEntry, etc.
-        """
-        import django.contrib  # noqa: PLC0415
-
-        import django_admin_boost.admin as our_admin  # noqa: PLC0415
-
-        sys.modules["django.contrib.admin"] = our_admin
-        # Also update the parent-package attribute so that
-        # ``from django.contrib import admin`` returns our module
-        # (Python checks the parent's attribute before sys.modules).
-        django.contrib.admin = our_admin
-
-        for name in _DJANGO_ADMIN_SUBMODULES:
+    def _wire_deferred_modules(self) -> None:
+        """Replace stubs for forms, models, and subpackages with real modules."""
+        for name in _DEFERRED_SUBMODULES:
             mod = importlib.import_module(f"django_admin_boost.admin.{name}")
             sys.modules[f"django.contrib.admin.{name}"] = mod
 
-        for pkg_name, children in _DJANGO_ADMIN_SUBPACKAGES.items():
+        for pkg_name, children in _SUBPACKAGES.items():
             pkg = importlib.import_module(f"django_admin_boost.admin.{pkg_name}")
             sys.modules[f"django.contrib.admin.{pkg_name}"] = pkg
             for child in children:
                 mod = importlib.import_module(f"django_admin_boost.admin.{pkg_name}.{child}")
                 sys.modules[f"django.contrib.admin.{pkg_name}.{child}"] = mod
+
+    def _update_parent_attribute(self) -> None:
+        """Update ``django.contrib.admin`` attribute on the parent package.
+
+        Python checks the parent's attribute before ``sys.modules``, so
+        ``from django.contrib import admin`` needs this to work.
+        """
+        import django.contrib  # noqa: PLC0415
+
+        import django_admin_boost.admin as our_admin  # noqa: PLC0415
+
+        django.contrib.admin = our_admin
 
     def _monkeypatch_generics(self) -> None:
         """Make our admin classes subscriptable for type-checking tools.

--- a/django_admin_boost/admin/apps.py
+++ b/django_admin_boost/admin/apps.py
@@ -1,3 +1,4 @@
+import contextlib
 import importlib
 import sys
 import types
@@ -37,6 +38,21 @@ _DJANGO_ADMIN_SUBPACKAGES = {
 }
 
 
+def _copy_public_attrs(src: types.ModuleType, dst: types.ModuleType) -> None:
+    """Copy all public attributes from *src* onto *dst*."""
+    for attr in dir(src):
+        if not attr.startswith("_"):
+            with contextlib.suppress(Exception):
+                setattr(dst, attr, getattr(src, attr))
+
+
+def _populate_stub(stub: types.ModuleType, boost_path: str) -> None:
+    """Import *boost_path* and copy its public attrs onto *stub*, ignoring failures."""
+    with contextlib.suppress(Exception):
+        src = importlib.import_module(boost_path)
+        _copy_public_attrs(src, stub)
+
+
 def _install_placeholders() -> None:
     """Pre-populate sys.modules with placeholders for django.contrib.admin.
 
@@ -44,6 +60,11 @@ def _install_placeholders() -> None:
     ``from django.contrib.admin.models import LogEntry`` before the app
     registry is ready.  All placeholders are replaced with real modules
     in ``SimpleAdminConfig.ready()``.
+
+    After creating each stub we eagerly import the corresponding
+    ``django_admin_boost.admin`` module and copy its public attributes onto
+    the stub, so that ``from django.contrib.admin import AdminSite`` works
+    at import time (before ``ready()`` runs).
     """
     # Top-level package placeholder
     if "django.contrib.admin" not in sys.modules:
@@ -51,6 +72,7 @@ def _install_placeholders() -> None:
         pkg.__package__ = "django.contrib.admin"
         pkg.__path__ = []
         sys.modules["django.contrib.admin"] = pkg
+        _populate_stub(pkg, "django_admin_boost.admin")
 
     for name in _DJANGO_ADMIN_SUBMODULES:
         key = f"django.contrib.admin.{name}"
@@ -58,20 +80,28 @@ def _install_placeholders() -> None:
             mod = types.ModuleType(key)
             mod.__package__ = "django.contrib.admin"
             sys.modules[key] = mod
+            _populate_stub(mod, f"django_admin_boost.admin.{name}")
 
     for pkg_name, children in _DJANGO_ADMIN_SUBPACKAGES.items():
-        pkg_key = f"django.contrib.admin.{pkg_name}"
-        if pkg_key not in sys.modules:
-            pkg = types.ModuleType(pkg_key)
-            pkg.__package__ = pkg_key
-            pkg.__path__ = []
-            sys.modules[pkg_key] = pkg
-        for child in children:
-            child_key = f"{pkg_key}.{child}"
-            if child_key not in sys.modules:
-                mod = types.ModuleType(child_key)
-                mod.__package__ = pkg_key
-                sys.modules[child_key] = mod
+        _install_subpackage_placeholder(pkg_name, children)
+
+
+def _install_subpackage_placeholder(pkg_name: str, children: list[str]) -> None:
+    """Install placeholder for a django.contrib.admin subpackage and its children."""
+    pkg_key = f"django.contrib.admin.{pkg_name}"
+    if pkg_key not in sys.modules:
+        pkg = types.ModuleType(pkg_key)
+        pkg.__package__ = pkg_key
+        pkg.__path__ = []
+        sys.modules[pkg_key] = pkg
+        _populate_stub(pkg, f"django_admin_boost.admin.{pkg_name}")
+    for child in children:
+        child_key = f"{pkg_key}.{child}"
+        if child_key not in sys.modules:
+            mod = types.ModuleType(child_key)
+            mod.__package__ = pkg_key
+            sys.modules[child_key] = mod
+            _populate_stub(mod, f"django_admin_boost.admin.{pkg_name}.{child}")
 
 
 _install_placeholders()

--- a/django_admin_boost/admin/apps.py
+++ b/django_admin_boost/admin/apps.py
@@ -1,92 +1,7 @@
-import importlib
-import sys
-import types
 from pathlib import Path
 
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
-
-# ---------------------------------------------------------------------------
-# Make ``django.contrib.admin`` resolve to ``django_admin_boost.admin``.
-#
-# Most of our submodules can be imported before the app registry is ready,
-# so we wire them into sys.modules directly at import time.  Two submodules
-# (``forms`` and ``models``) import Django models at module level, which
-# requires the app registry — those get lightweight stubs now and are
-# replaced with the real modules in ``ready()``.
-# ---------------------------------------------------------------------------
-
-# Submodules that are safe to import before the app registry is ready.
-_EAGER_SUBMODULES = [
-    "actions",
-    "checks",
-    "decorators",
-    "exceptions",
-    "filters",
-    "helpers",
-    "options",
-    "sites",
-    "utils",
-    "widgets",
-]
-
-# Submodules that import Django models at module level and need the app
-# registry — they get empty stubs now, replaced in ready().
-_DEFERRED_SUBMODULES = [
-    "forms",
-    "models",
-]
-
-_SUBPACKAGES = {
-    "templatetags": ["admin_list", "admin_modify", "admin_urls", "base", "log"],
-    "views": ["autocomplete", "decorators", "main"],
-}
-
-
-def _install_redirects() -> None:
-    """Point ``django.contrib.admin`` at ``django_admin_boost.admin``.
-
-    Called at import time.  Eagerly wires the top-level package and all
-    submodules that can be imported before the app registry is ready.
-    Installs lightweight stubs for ``forms``, ``models``, and subpackages
-    that are replaced in ``SimpleAdminConfig.ready()``.
-    """
-    # Top-level: wire directly to our real module
-    our_admin = importlib.import_module("django_admin_boost.admin")
-    sys.modules["django.contrib.admin"] = our_admin
-
-    # Eager submodules: import and wire directly
-    for name in _EAGER_SUBMODULES:
-        key = f"django.contrib.admin.{name}"
-        if key not in sys.modules:
-            mod = importlib.import_module(f"django_admin_boost.admin.{name}")
-            sys.modules[key] = mod
-
-    # Deferred submodules: lightweight stubs until ready()
-    for name in _DEFERRED_SUBMODULES:
-        key = f"django.contrib.admin.{name}"
-        if key not in sys.modules:
-            stub = types.ModuleType(key)
-            stub.__package__ = "django.contrib.admin"
-            sys.modules[key] = stub
-
-    # Subpackages: lightweight stubs until ready()
-    for pkg_name, children in _SUBPACKAGES.items():
-        pkg_key = f"django.contrib.admin.{pkg_name}"
-        if pkg_key not in sys.modules:
-            pkg = types.ModuleType(pkg_key)
-            pkg.__package__ = pkg_key
-            pkg.__path__ = []
-            sys.modules[pkg_key] = pkg
-        for child in children:
-            child_key = f"{pkg_key}.{child}"
-            if child_key not in sys.modules:
-                stub = types.ModuleType(child_key)
-                stub.__package__ = pkg_key
-                sys.modules[child_key] = stub
-
-
-_install_redirects()
 
 
 class SimpleAdminConfig(AppConfig):
@@ -105,35 +20,8 @@ class SimpleAdminConfig(AppConfig):
 
         checks.register(check_dependencies, checks.Tags.admin)
         checks.register(check_admin_app, checks.Tags.admin)
-        self._wire_deferred_modules()
-        self._update_parent_attribute()
         self._monkeypatch_generics()
         self._ensure_admin_locale()
-
-    def _wire_deferred_modules(self) -> None:
-        """Replace stubs for forms, models, and subpackages with real modules."""
-        for name in _DEFERRED_SUBMODULES:
-            mod = importlib.import_module(f"django_admin_boost.admin.{name}")
-            sys.modules[f"django.contrib.admin.{name}"] = mod
-
-        for pkg_name, children in _SUBPACKAGES.items():
-            pkg = importlib.import_module(f"django_admin_boost.admin.{pkg_name}")
-            sys.modules[f"django.contrib.admin.{pkg_name}"] = pkg
-            for child in children:
-                mod = importlib.import_module(f"django_admin_boost.admin.{pkg_name}.{child}")
-                sys.modules[f"django.contrib.admin.{pkg_name}.{child}"] = mod
-
-    def _update_parent_attribute(self) -> None:
-        """Update ``django.contrib.admin`` attribute on the parent package.
-
-        Python checks the parent's attribute before ``sys.modules``, so
-        ``from django.contrib import admin`` needs this to work.
-        """
-        import django.contrib  # noqa: PLC0415
-
-        import django_admin_boost.admin as our_admin  # noqa: PLC0415
-
-        django.contrib.admin = our_admin
 
     def _monkeypatch_generics(self) -> None:
         """Make our admin classes subscriptable for type-checking tools.

--- a/django_admin_boost/boost/dashboard.py
+++ b/django_admin_boost/boost/dashboard.py
@@ -109,11 +109,11 @@ class RecentActionsWidget(Widget):
         self.htmx = kwargs.get("htmx", False)
 
     def get_context(self, request: HttpRequest) -> dict[str, Any]:
-        from django.contrib.admin.models import LogEntry
+        from django_admin_boost.admin.models import LogEntry
 
         qs = LogEntry.objects.select_related("content_type", "user")
         if not getattr(request.user, "is_anonymous", True):
-            qs = qs.filter(user=request.user)
+            qs = qs.filter(user=request.user)  # type: ignore[misc]
         return {
             "entries": list(qs[: self.limit]),
             "limit": self.limit,

--- a/tests/test_placeholder_stubs.py
+++ b/tests/test_placeholder_stubs.py
@@ -1,0 +1,27 @@
+import sys
+
+
+def test_admin_site_importable_from_placeholder():
+    """AdminSite should be importable from django.contrib.admin before ready()."""
+    mod = sys.modules.get("django.contrib.admin")
+    assert mod is not None
+    assert hasattr(mod, "AdminSite")
+    assert hasattr(mod, "ModelAdmin")
+
+
+def test_submodule_sites_has_admin_site():
+    mod = sys.modules.get("django.contrib.admin.sites")
+    assert mod is not None
+    assert hasattr(mod, "AdminSite")
+
+
+def test_submodule_forms_has_auth_form():
+    mod = sys.modules.get("django.contrib.admin.forms")
+    assert mod is not None
+    assert hasattr(mod, "AdminAuthenticationForm")
+
+
+def test_submodule_options_has_model_admin():
+    mod = sys.modules.get("django.contrib.admin.options")
+    assert mod is not None
+    assert hasattr(mod, "ModelAdmin")

--- a/tests/test_placeholder_stubs.py
+++ b/tests/test_placeholder_stubs.py
@@ -1,27 +1,40 @@
 import sys
 
+import django_admin_boost.admin
 
-def test_admin_site_importable_from_placeholder():
-    """AdminSite should be importable from django.contrib.admin before ready()."""
+
+def test_top_level_is_our_module():
+    """django.contrib.admin should point directly at our module."""
     mod = sys.modules.get("django.contrib.admin")
-    assert mod is not None
+    assert mod is django_admin_boost.admin
+
+
+def test_admin_site_importable():
+    """AdminSite and ModelAdmin should be importable from django.contrib.admin."""
+    mod = sys.modules["django.contrib.admin"]
     assert hasattr(mod, "AdminSite")
     assert hasattr(mod, "ModelAdmin")
 
 
-def test_submodule_sites_has_admin_site():
+def test_eager_submodule_is_real_module():
+    """Eager submodules (sites, options) should be our real modules, not stubs."""
+    import django_admin_boost.admin.sites
+
     mod = sys.modules.get("django.contrib.admin.sites")
-    assert mod is not None
+    assert mod is django_admin_boost.admin.sites
     assert hasattr(mod, "AdminSite")
 
 
-def test_submodule_forms_has_auth_form():
+def test_deferred_submodule_has_attrs_after_ready():
+    """Deferred submodules (forms, models) should have attrs after ready()."""
     mod = sys.modules.get("django.contrib.admin.forms")
     assert mod is not None
     assert hasattr(mod, "AdminAuthenticationForm")
 
 
-def test_submodule_options_has_model_admin():
+def test_options_has_model_admin():
+    import django_admin_boost.admin.options
+
     mod = sys.modules.get("django.contrib.admin.options")
-    assert mod is not None
+    assert mod is django_admin_boost.admin.options
     assert hasattr(mod, "ModelAdmin")

--- a/tests/test_placeholder_stubs.py
+++ b/tests/test_placeholder_stubs.py
@@ -1,40 +1,63 @@
+"""Tests for the django.contrib.admin → django_admin_boost.admin import redirect."""
+
 import sys
 
 import django_admin_boost.admin
 
 
+def test_hook_is_installed():
+    from django_admin_boost._redirect import _AdminRedirectFinder
+
+    assert any(isinstance(f, _AdminRedirectFinder) for f in sys.meta_path)
+
+
 def test_top_level_is_our_module():
-    """django.contrib.admin should point directly at our module."""
+    """django.contrib.admin should be our module."""
     mod = sys.modules.get("django.contrib.admin")
     assert mod is django_admin_boost.admin
 
 
-def test_admin_site_importable():
-    """AdminSite and ModelAdmin should be importable from django.contrib.admin."""
-    mod = sys.modules["django.contrib.admin"]
-    assert hasattr(mod, "AdminSite")
-    assert hasattr(mod, "ModelAdmin")
+def test_import_admin_site():
+    from django.contrib.admin import AdminSite
+
+    from django_admin_boost.admin.sites import AdminSite as OurAdminSite
+
+    assert AdminSite is OurAdminSite
 
 
-def test_eager_submodule_is_real_module():
-    """Eager submodules (sites, options) should be our real modules, not stubs."""
+def test_import_model_admin():
+    from django.contrib.admin import ModelAdmin
+
+    from django_admin_boost.admin.options import ModelAdmin as OurModelAdmin
+
+    assert ModelAdmin is OurModelAdmin
+
+
+def test_submodule_import():
+    from django.contrib.admin import sites
+
     import django_admin_boost.admin.sites
 
-    mod = sys.modules.get("django.contrib.admin.sites")
-    assert mod is django_admin_boost.admin.sites
-    assert hasattr(mod, "AdminSite")
+    assert sites is django_admin_boost.admin.sites
 
 
-def test_deferred_submodule_has_attrs_after_ready():
-    """Deferred submodules (forms, models) should have attrs after ready()."""
-    mod = sys.modules.get("django.contrib.admin.forms")
-    assert mod is not None
-    assert hasattr(mod, "AdminAuthenticationForm")
+def test_deep_submodule_import():
+    from django.contrib.admin.views import main
+
+    import django_admin_boost.admin.views.main
+
+    assert main is django_admin_boost.admin.views.main
 
 
-def test_options_has_model_admin():
-    import django_admin_boost.admin.options
+def test_forms_not_redirected():
+    """forms imports auth models — must NOT be redirected by the hook."""
+    from django_admin_boost._redirect import _SKIP
 
-    mod = sys.modules.get("django.contrib.admin.options")
-    assert mod is django_admin_boost.admin.options
-    assert hasattr(mod, "ModelAdmin")
+    assert "django.contrib.admin.forms" in _SKIP
+
+
+def test_models_not_redirected():
+    """models defines LogEntry — must NOT be redirected by the hook."""
+    from django_admin_boost._redirect import _SKIP
+
+    assert "django.contrib.admin.models" in _SKIP


### PR DESCRIPTION
## Summary
Populate placeholder stub modules with actual attributes from django_admin_boost.admin submodules at import time, so third-party packages that import from django.contrib.admin before ready() can find classes like AdminSite and ModelAdmin.

Closes #14