### PR TITLE
feat: strip display-only annotations from count queryset

### DIFF
--- a/django_admin_boost/paginators.py
+++ b/django_admin_boost/paginators.py
@@ -75,6 +75,8 @@ class EstimatedCountPaginator(Paginator):
 
         # Check ORDER BY
         for ordering in queryset.query.order_by:
+            if not isinstance(ordering, str):
+                continue
             clean_name = ordering.lstrip("-")
             if clean_name in queryset.query.annotations:
                 referenced.add(clean_name)

--- a/django_admin_boost/paginators.py
+++ b/django_admin_boost/paginators.py
@@ -42,7 +42,44 @@ class EstimatedCountPaginator(Paginator):
                 self._used_estimate = True
                 return int(estimate)
 
+        # Strip display-only annotations for a lighter count query
+        return self._smart_count(queryset)
+
+    def _smart_count(self, queryset: QuerySet) -> int:
+        """Count rows, stripping annotations not needed for filtering/ordering."""
+        annotations_in_use = self._get_referenced_annotations(queryset)
+        all_annotations = set(queryset.query.annotations.keys())
+        display_only = all_annotations - annotations_in_use
+
+        if display_only:
+            # Create a stripped queryset for counting
+            count_qs = queryset.all()  # clone
+            for name in display_only:
+                count_qs.query.annotations.pop(name, None)
+            # Recalculate group_by after removing annotations; otherwise Django
+            # may issue a flat COUNT(*) over the join and return wrong results.
+            count_qs.query.set_group_by()
+            return count_qs.count()
+
         return queryset.count()
+
+    def _get_referenced_annotations(self, queryset: QuerySet) -> set[str]:
+        """Return annotation names referenced by WHERE or ORDER BY clauses."""
+        referenced = set()
+
+        # Check WHERE clause
+        where_sql = str(queryset.query.where)
+        for name in queryset.query.annotations:
+            if name in where_sql:
+                referenced.add(name)
+
+        # Check ORDER BY
+        for ordering in queryset.query.order_by:
+            clean_name = ordering.lstrip("-")
+            if clean_name in queryset.query.annotations:
+                referenced.add(clean_name)
+
+        return referenced
 
     @property
     def is_approximate_count(self) -> bool:

--- a/tests/test_split_count.py
+++ b/tests/test_split_count.py
@@ -1,0 +1,58 @@
+import pytest
+from django.db.models import Count
+
+from django_admin_boost.paginators import EstimatedCountPaginator
+from tests.testapp.models import Article, Category
+
+
+@pytest.fixture
+def articles_with_categories(db):
+    cat = Category.objects.create(name="News")
+    for i in range(10):
+        Article.objects.create(title=f"Article {i}", category=cat)
+    return cat
+
+
+def test_count_strips_display_annotations(articles_with_categories):
+    """Display-only annotations should be stripped from count query."""
+    qs = Category.objects.annotate(article_count=Count("article"))
+    paginator = EstimatedCountPaginator(qs, per_page=10)
+    # Count should work and return 1
+    assert paginator.count == 1
+
+
+def test_count_preserves_filter_annotations(db):
+    """Annotations used in filters should be preserved."""
+    Category.objects.create(name="Empty")
+    cat = Category.objects.create(name="Has articles")
+    Article.objects.create(title="A1", category=cat)
+
+    qs = Category.objects.annotate(
+        article_count=Count("article"),
+    ).filter(article_count__gt=0)
+
+    paginator = EstimatedCountPaginator(qs, per_page=10)
+    assert paginator.count == 1
+
+
+def test_count_no_annotations_unchanged(db):
+    """Queryset without annotations should count normally."""
+    for i in range(5):
+        Article.objects.create(title=f"Article {i}")
+
+    qs = Article.objects.all()
+    paginator = EstimatedCountPaginator(qs, per_page=10)
+    assert paginator.count == 5
+
+
+def test_count_preserves_ordering_annotations(db):
+    """Annotations used in ordering should be preserved."""
+    cat = Category.objects.create(name="News")
+    Article.objects.create(title="A1", category=cat)
+
+    qs = Category.objects.annotate(
+        article_count=Count("article"),
+    ).order_by("-article_count")
+
+    paginator = EstimatedCountPaginator(qs, per_page=10)
+    assert paginator.count == 1


### PR DESCRIPTION
## Summary
When counting rows for pagination, strip annotations that are only used for display (not in WHERE or ORDER BY). This avoids unnecessary computation in the count query for annotated changelists.

Closes #5