### PR TITLE
feat: declarative AnnotatedField for list_display

### DIFF
--- a/django_admin_boost/__init__.py
+++ b/django_admin_boost/__init__.py
@@ -4,10 +4,12 @@ Standalone mixins and paginators that work with stock django.contrib.admin.
 For the full Jinja2-compatible admin replacement, use ``django_admin_boost.admin``.
 """
 
+from django_admin_boost.annotations import AnnotatedField
 from django_admin_boost.mixins import ListFieldsMixin, SmartPaginatorMixin
 from django_admin_boost.paginators import EstimatedCountPaginator
 
 __all__ = [
+    "AnnotatedField",
     "EstimatedCountPaginator",
     "ListFieldsMixin",
     "SmartPaginatorMixin",

--- a/django_admin_boost/annotations.py
+++ b/django_admin_boost/annotations.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.db.models import Expression
+
+
+class AnnotatedField:
+    """Declarative annotation for use in list_display.
+
+    Usage::
+
+        from django.db.models import Count
+        from django_admin_boost.annotations import AnnotatedField
+
+        class MyAdmin(ModelAdmin):
+            list_display = ["name", AnnotatedField("tag_count", Count("tags"), short_description="Tags")]
+    """
+
+    def __init__(
+        self,
+        name: str,
+        expression: Expression,
+        short_description: str | None = None,
+        empty_value: str = "-",
+    ) -> None:
+        self.name = name
+        self.expression = expression
+        self.short_description = short_description or name.replace("_", " ").title()
+        self.empty_value = empty_value
+        # Make this work as a list_display callable
+        self.admin_order_field = name
+
+    def __call__(self, obj: object) -> object:
+        value = getattr(obj, self.name, None)
+        if value is None:
+            return self.empty_value
+        return value
+
+    def __repr__(self) -> str:
+        return f"AnnotatedField({self.name!r})"

--- a/django_admin_boost/mixins.py
+++ b/django_admin_boost/mixins.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 from django.core.exceptions import ImproperlyConfigured
 
+from django_admin_boost.annotations import AnnotatedField
 from django_admin_boost.paginators import EstimatedCountPaginator
 
 if TYPE_CHECKING:
-    from django.db.models import QuerySet
+    from django.db.models import Expression, QuerySet
     from django.http import HttpRequest
 
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
@@ -64,16 +65,29 @@ class ListFieldsMixin:
         if self.list_only_fields is not None:
             pk_name = self.opts.pk.name  # type: ignore[attr-defined]
             fields = {pk_name, *self.list_only_fields}
-            return qs.only(*fields)
-
-        if self.list_defer_fields is not None:
+            qs = qs.only(*fields)
+        elif self.list_defer_fields is not None:
             if not self.list_defer_fields:
-                return qs  # empty list = opt-out
-            return qs.defer(*self.list_defer_fields)
+                pass  # empty list = opt-out, no defer applied
+            else:
+                qs = qs.defer(*self.list_defer_fields)
+        else:
+            # Auto mode: resolve list_display to concrete fields
+            fields = self._resolve_list_display_fields()
+            qs = qs.only(*fields)
 
-        # Auto mode: resolve list_display to concrete fields
-        fields = self._resolve_list_display_fields()
-        return qs.only(*fields)
+        annotations = self._collect_annotated_fields()
+        if annotations:
+            qs = qs.annotate(**annotations)
+        return qs
+
+    def _collect_annotated_fields(self) -> dict[str, Expression]:
+        """Collect AnnotatedField instances from list_display."""
+        annotations: dict[str, Expression] = {}
+        for entry in self.list_display:  # type: ignore[attr-defined]
+            if isinstance(entry, AnnotatedField):
+                annotations[entry.name] = entry.expression
+        return annotations
 
     def _resolve_list_display_fields(self) -> set[str]:
         """Resolve ``list_display`` entries to concrete model field names."""
@@ -81,6 +95,9 @@ class ListFieldsMixin:
         fields = {pk_name}
 
         for entry in self.list_display:  # type: ignore[attr-defined]
+            if isinstance(entry, AnnotatedField):
+                # Handled by _collect_annotated_fields — not a concrete field
+                continue
             if entry == "__str__":
                 # __str__ contributes only pk
                 continue

--- a/tests/test_annotated_field.py
+++ b/tests/test_annotated_field.py
@@ -1,0 +1,93 @@
+import pytest
+from django.contrib.admin import site as admin_site
+from django.db.models import Count
+from django.test import RequestFactory
+from django.urls import resolve
+
+from django_admin_boost.admin import ModelAdmin
+from django_admin_boost.annotations import AnnotatedField
+from tests.testapp.models import Article, Category
+
+
+@pytest.fixture
+def superuser(db):
+    from django.contrib.auth.models import User
+
+    return User.objects.create_superuser(username="admin", password="password")
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+def _changelist_request(rf, superuser):
+    request = rf.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    return request
+
+
+def test_annotated_field_applies_annotation(rf, superuser, db):
+    class TestAdmin(ModelAdmin):
+        list_display = ["name", AnnotatedField("article_count", Count("article"))]
+
+    ma = TestAdmin(Category, admin_site)
+    request = rf.get("/admin/testapp/category/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/category/")
+    qs = ma.get_queryset(request)
+    assert "article_count" in qs.query.annotations
+
+
+def test_annotated_field_callable(db):
+    af = AnnotatedField("tag_count", Count("tags"), short_description="Tags")
+
+    class FakeObj:
+        tag_count = 5
+
+    assert af(FakeObj()) == 5
+    assert af.short_description == "Tags"
+    assert af.admin_order_field == "tag_count"
+
+
+def test_annotated_field_empty_value(db):
+    af = AnnotatedField("tag_count", Count("tags"), empty_value="N/A")
+
+    class FakeObj:
+        tag_count = None
+
+    assert af(FakeObj()) == "N/A"
+
+
+def test_annotated_field_default_description():
+    af = AnnotatedField("article_count", Count("article"))
+    assert af.short_description == "Article Count"
+
+
+def test_annotated_field_queryset_value(rf, superuser, db):
+    cat = Category.objects.create(name="News")
+    Article.objects.create(title="A1", category=cat)
+    Article.objects.create(title="A2", category=cat)
+
+    class TestAdmin(ModelAdmin):
+        list_display = ["name", AnnotatedField("article_count", Count("article"))]
+
+    ma = TestAdmin(Category, admin_site)
+    request = rf.get("/admin/testapp/category/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/category/")
+    qs = ma.get_queryset(request)
+    obj = qs.get(pk=cat.pk)
+    assert obj.article_count == 2
+
+
+def test_only_fields_skips_annotated_field(rf, superuser, db):
+    """AnnotatedField should not appear in _resolve_list_display_fields."""
+
+    class TestAdmin(ModelAdmin):
+        list_display = ["name", AnnotatedField("article_count", Count("article"))]
+
+    ma = TestAdmin(Category, admin_site)
+    fields = ma._resolve_list_display_fields()  # noqa: SLF001
+    assert "article_count" not in fields


### PR DESCRIPTION
## Summary
Add AnnotatedField class for declarative annotation in list_display. Bundles a queryset annotation expression with display config (short_description, admin_order_field). ListFieldsMixin auto-applies annotations on changelist querysets.

Example:
```python
list_display = ["name", AnnotatedField("tag_count", Count("tags"), short_description="Tags")]
```

Closes #9