### PR TITLE
refactor: convert all tests to pytest-django style

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,27 @@
 """Pytest configuration."""
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import RequestFactory
+
+from tests.testapp.models import Article, Category
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser(username="admin", password="password")
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture
+def category(db):
+    return Category.objects.create(name="News")
+
+
+@pytest.fixture
+def articles_10(db):
+    return [Article.objects.create(title=f"Article {i}", status="published") for i in range(10)]

--- a/tests/test_boost_dashboard.py
+++ b/tests/test_boost_dashboard.py
@@ -1,4 +1,4 @@
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 
 from django_admin_boost.boost.dashboard import (
     ChartWidget,
@@ -9,85 +9,83 @@ from django_admin_boost.boost.dashboard import (
 )
 
 
-class WidgetBaseTest(TestCase):
-    def test_widget_has_template_and_htmx_attrs(self):
-        w = Widget()
-        assert hasattr(w, "template_name")
-        assert hasattr(w, "htmx")
-        assert w.htmx is False
-
-    def test_widget_get_context_raises(self):
-        import pytest
-
-        w = Widget()
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        with pytest.raises(NotImplementedError):
-            w.get_context(request)
+def test_widget_has_template_and_htmx_attrs():
+    w = Widget()
+    assert hasattr(w, "template_name")
+    assert hasattr(w, "htmx")
+    assert w.htmx is False
 
 
-class ValueWidgetTest(TestCase):
-    def test_value_widget_context(self):
-        w = ValueWidget(label="Total Users", value=1234, icon="people")
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        ctx = w.get_context(request)
-        assert ctx["label"] == "Total Users"
-        assert ctx["value"] == 1234
-        assert ctx["icon"] == "people"
+def test_widget_get_context_raises():
+    import pytest
 
-    def test_value_widget_callable_value(self):
-        w = ValueWidget(label="Count", value=lambda request: 42)
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        ctx = w.get_context(request)
-        assert ctx["value"] == 42
+    w = Widget()
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    with pytest.raises(NotImplementedError):
+        w.get_context(request)
 
 
-class TableWidgetTest(TestCase):
-    def test_table_widget_context(self):
-        w = TableWidget(
-            title="Recent Orders",
-            headers=["ID", "Customer", "Total"],
-            rows=lambda request: [["1", "Alice", "$100"], ["2", "Bob", "$200"]],
-        )
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        ctx = w.get_context(request)
-        assert ctx["title"] == "Recent Orders"
-        assert ctx["headers"] == ["ID", "Customer", "Total"]
-        assert len(ctx["rows"]) == 2
+def test_value_widget_context():
+    w = ValueWidget(label="Total Users", value=1234, icon="people")
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    ctx = w.get_context(request)
+    assert ctx["label"] == "Total Users"
+    assert ctx["value"] == 1234
+    assert ctx["icon"] == "people"
 
 
-class ChartWidgetTest(TestCase):
-    def test_chart_widget_is_htmx_by_default(self):
-        w = ChartWidget(
-            title="Sales",
-            chart_type="bar",
-            data=lambda request: {"labels": ["Jan"], "datasets": [{"data": [10]}]},
-        )
-        assert w.htmx is True
-
-    def test_chart_widget_context(self):
-        w = ChartWidget(
-            title="Sales",
-            chart_type="bar",
-            data=lambda request: {"labels": ["Jan"], "datasets": [{"data": [10]}]},
-        )
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        ctx = w.get_context(request)
-        assert ctx["title"] == "Sales"
-        assert ctx["chart_type"] == "bar"
-        assert "labels" in ctx["data"]
+def test_value_widget_callable_value():
+    w = ValueWidget(label="Count", value=lambda request: 42)
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    ctx = w.get_context(request)
+    assert ctx["value"] == 42
 
 
-class RecentActionsWidgetTest(TestCase):
-    def test_recent_actions_widget_context(self):
-        w = RecentActionsWidget(limit=5)
-        factory = RequestFactory()
-        request = factory.get("/admin/")
-        request.user = type("User", (), {"is_anonymous": True, "pk": None})()
-        ctx = w.get_context(request)
-        assert "entries" in ctx
-        assert ctx["limit"] == 5
+def test_table_widget_context():
+    w = TableWidget(
+        title="Recent Orders",
+        headers=["ID", "Customer", "Total"],
+        rows=lambda request: [["1", "Alice", "$100"], ["2", "Bob", "$200"]],
+    )
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    ctx = w.get_context(request)
+    assert ctx["title"] == "Recent Orders"
+    assert ctx["headers"] == ["ID", "Customer", "Total"]
+    assert len(ctx["rows"]) == 2
+
+
+def test_chart_widget_is_htmx_by_default():
+    w = ChartWidget(
+        title="Sales",
+        chart_type="bar",
+        data=lambda request: {"labels": ["Jan"], "datasets": [{"data": [10]}]},
+    )
+    assert w.htmx is True
+
+
+def test_chart_widget_context():
+    w = ChartWidget(
+        title="Sales",
+        chart_type="bar",
+        data=lambda request: {"labels": ["Jan"], "datasets": [{"data": [10]}]},
+    )
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    ctx = w.get_context(request)
+    assert ctx["title"] == "Sales"
+    assert ctx["chart_type"] == "bar"
+    assert "labels" in ctx["data"]
+
+
+def test_recent_actions_widget_context(db):
+    w = RecentActionsWidget(limit=5)
+    factory = RequestFactory()
+    request = factory.get("/admin/")
+    request.user = type("User", (), {"is_anonymous": True, "pk": None})()
+    ctx = w.get_context(request)
+    assert "entries" in ctx
+    assert ctx["limit"] == 5

--- a/tests/test_boost_views.py
+++ b/tests/test_boost_views.py
@@ -1,5 +1,6 @@
+import pytest
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from django_admin_boost.admin.options import ModelAdmin
 from django_admin_boost.boost import site as boost_site
@@ -60,75 +61,104 @@ BOOST_SETTINGS = {
 }
 
 
+@pytest.fixture
+def boost_setup(db):
+    admin_user = User.objects.create_superuser("admin", "admin@test.com", "password")
+    category = Category.objects.create(name="Tech")
+    article = Article.objects.create(
+        title="Test Article",
+        slug="test-article",
+        body="Test body",
+        category=category,
+        status=Article.Status.PUBLISHED,
+    )
+    return admin_user, category, article
+
+
 @override_settings(**BOOST_SETTINGS)
-class BoostAdminViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.admin_user = User.objects.create_superuser("admin", "admin@test.com", "password")
-        cls.category = Category.objects.create(name="Tech")
-        cls.article = Article.objects.create(
-            title="Test Article",
-            slug="test-article",
-            body="Test body",
-            category=cls.category,
-            status=Article.Status.PUBLISHED,
+def test_boost_index(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_app_index(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/testapp/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_change_list(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/testapp/article/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_add_form(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/testapp/article/add/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_change_form(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get(f"/admin/testapp/article/{article.pk}/change/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_delete_confirmation(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get(f"/admin/testapp/article/{article.pk}/delete/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_object_history(client, boost_setup):
+    admin_user, category, article = boost_setup
+    client.force_login(admin_user)
+    response = client.get(f"/admin/testapp/article/{article.pk}/history/")
+    assert response.status_code == 200
+
+
+@override_settings(**BOOST_SETTINGS)
+def test_boost_login_page(client):
+    response = client.get("/admin/login/")
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def boost_search_filter_setup(db):
+    admin_user = User.objects.create_superuser("admin", "admin@test.com", "password")
+    for i in range(25):
+        Article.objects.create(
+            title=f"Article {i}",
+            status=Article.Status.PUBLISHED if i % 2 else Article.Status.DRAFT,
         )
-
-    def setUp(self):
-        self.client.force_login(self.admin_user)
-
-    def test_index(self):
-        response = self.client.get("/admin/")
-        assert response.status_code == 200
-
-    def test_app_index(self):
-        response = self.client.get("/admin/testapp/")
-        assert response.status_code == 200
-
-    def test_change_list(self):
-        response = self.client.get("/admin/testapp/article/")
-        assert response.status_code == 200
-
-    def test_add_form(self):
-        response = self.client.get("/admin/testapp/article/add/")
-        assert response.status_code == 200
-
-    def test_change_form(self):
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/change/")
-        assert response.status_code == 200
-
-    def test_delete_confirmation(self):
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/delete/")
-        assert response.status_code == 200
-
-    def test_object_history(self):
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/history/")
-        assert response.status_code == 200
-
-    def test_login_page(self):
-        self.client.logout()
-        response = self.client.get("/admin/login/")
-        assert response.status_code == 200
+    return admin_user
 
 
 @override_settings(**BOOST_SETTINGS)
-class BoostAdminSearchFilterTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.admin_user = User.objects.create_superuser("admin", "admin@test.com", "password")
-        for i in range(25):
-            Article.objects.create(
-                title=f"Article {i}",
-                status=Article.Status.PUBLISHED if i % 2 else Article.Status.DRAFT,
-            )
+def test_boost_search(client, boost_search_filter_setup):
+    admin_user = boost_search_filter_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/testapp/article/?q=Article+1")
+    assert response.status_code == 200
 
-    def setUp(self):
-        self.client.force_login(self.admin_user)
 
-    def test_search(self):
-        response = self.client.get("/admin/testapp/article/?q=Article+1")
-        assert response.status_code == 200
-
-    def test_filter(self):
-        response = self.client.get("/admin/testapp/article/?status__exact=published")
-        assert response.status_code == 200
+@override_settings(**BOOST_SETTINGS)
+def test_boost_filter(client, boost_search_filter_setup):
+    admin_user = boost_search_filter_setup
+    client.force_login(admin_user)
+    response = client.get("/admin/testapp/article/?status__exact=published")
+    assert response.status_code == 200

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -4,116 +4,115 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from django.contrib.auth.models import User
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 
 from django_admin_boost import admin
 from django_admin_boost.admin import ModelAdmin
 from tests.testapp.models import Article
 
 
-class DocstringAccuracyTest(TestCase):
-    """Issues #4 and #5: docstrings must reference correct module paths."""
+def test_jinja2_env_docstring_has_correct_path():
+    """Issue #4: jinja2_env.environment docstring must use 'django_admin_boost.admin.jinja2_env.environment'."""
+    from django_admin_boost.admin.jinja2_env import environment
 
-    def test_jinja2_env_docstring_has_correct_path(self):
-        """Issue #4: jinja2_env.environment docstring must use 'django_admin_boost.admin.jinja2_env.environment'."""
-        from django_admin_boost.admin.jinja2_env import environment
-
-        docstring = environment.__doc__
-        assert "django_admin_boost.admin.jinja2_env.environment" in docstring, (
-            f"Docstring contains wrong path. Expected 'django_admin_boost.admin.jinja2_env.environment' but got: {docstring}"
-        )
-        assert "django_admin_boost.jinja2_env.environment" not in docstring.replace(
-            "django_admin_boost.admin.jinja2_env.environment",
-            "",
-        ), "Docstring still contains the wrong path 'django_admin_boost.jinja2_env.environment'"
-
-    def test_top_level_init_docstring_has_correct_module(self):
-        """Issue #5: __init__.py docstring must reference 'django_admin_boost.admin', not 'django_admin_boost.adminx'."""
-        import django_admin_boost
-
-        docstring = django_admin_boost.__doc__
-        assert "django_admin_boost.admin" in docstring
-        assert "django_admin_boost.adminx" not in docstring, (
-            "Docstring references non-existent module 'django_admin_boost.adminx'. Should be 'django_admin_boost.admin'."
-        )
+    docstring = environment.__doc__
+    assert "django_admin_boost.admin.jinja2_env.environment" in docstring, (
+        f"Docstring contains wrong path. Expected 'django_admin_boost.admin.jinja2_env.environment' but got: {docstring}"
+    )
+    assert "django_admin_boost.jinja2_env.environment" not in docstring.replace(
+        "django_admin_boost.admin.jinja2_env.environment",
+        "",
+    ), "Docstring still contains the wrong path 'django_admin_boost.jinja2_env.environment'"
 
 
-class UUIDFallbackDetectionTest(TestCase):
-    """Issue #7: _is_changelist_request fallback must detect UUID PKs."""
+def test_top_level_init_docstring_has_correct_module():
+    """Issue #5: __init__.py docstring must reference 'django_admin_boost.admin', not 'django_admin_boost.adminx'."""
+    import django_admin_boost
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
-
-        class TestArticleAdmin(ModelAdmin):
-            list_only_fields = ["id", "title"]
-
-        self.model_admin = TestArticleAdmin(Article, self.site)
-
-    def test_uuid_pk_detected_as_change_view(self):
-        """A UUID PK in the URL path should be detected as a change view (not changelist)."""
-        request = self.factory.get("/admin/testapp/article/550e8400-e29b-41d4-a716-446655440000/change/")
-        # Deliberately remove resolver_match to exercise fallback path
-        request.resolver_match = None
-        result = self.model_admin._is_changelist_request(request)  # noqa: SLF001
-        assert result is False, "UUID PK path should be detected as change view, not changelist"
-
-    def test_uuid_pk_without_change_suffix_detected(self):
-        """A URL ending with a UUID PK (no /change/ suffix) should be detected as a change view."""
-        request = self.factory.get("/admin/testapp/article/550e8400-e29b-41d4-a716-446655440000/")
-        request.resolver_match = None
-        result = self.model_admin._is_changelist_request(request)  # noqa: SLF001
-        assert result is False, "URL ending with UUID PK should be detected as change view"
-
-    def test_digit_pk_still_detected(self):
-        """Numeric PKs should still be detected as change views in fallback."""
-        request = self.factory.get("/admin/testapp/article/42/")
-        request.resolver_match = None
-        result = self.model_admin._is_changelist_request(request)  # noqa: SLF001
-        assert result is False
-
-    def test_changelist_path_returns_true(self):
-        """A changelist path should return True in fallback."""
-        request = self.factory.get("/admin/testapp/article/")
-        request.resolver_match = None
-        result = self.model_admin._is_changelist_request(request)  # noqa: SLF001
-        assert result is True
+    docstring = django_admin_boost.__doc__
+    assert "django_admin_boost.admin" in docstring
+    assert "django_admin_boost.adminx" not in docstring, (
+        "Docstring references non-existent module 'django_admin_boost.adminx'. Should be 'django_admin_boost.admin'."
+    )
 
 
-class AdminLocaleTest(TestCase):
-    """Issue #2: Django admin translations must still be loadable."""
+@pytest.fixture
+def uuid_test_setup(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    site = admin.AdminSite()
 
-    def test_django_admin_locale_path_is_discoverable(self):
-        """The Django admin locale directory must be in LOCALE_PATHS or discoverable."""
-        import django
+    class TestArticleAdmin(ModelAdmin):
+        list_only_fields = ["id", "title"]
 
-        django_admin_locale = Path(django.__file__).parent / "contrib" / "admin" / "locale"
-        assert django_admin_locale.is_dir(), "Django admin locale dir not found"
+    model_admin = TestArticleAdmin(Article, site)
+    return superuser, model_admin
 
-        # After adminx replaces django.contrib.admin, the admin locale must
-        # still be discoverable via LOCALE_PATHS
-        from django.conf import settings
 
-        locale_paths = list(getattr(settings, "LOCALE_PATHS", []))
+def test_uuid_pk_detected_as_change_view(uuid_test_setup):
+    """Issue #7: A UUID PK in the URL path should be detected as a change view (not changelist)."""
+    superuser, model_admin = uuid_test_setup
+    factory = RequestFactory()
+    request = factory.get("/admin/testapp/article/550e8400-e29b-41d4-a716-446655440000/change/")
+    request.resolver_match = None
+    result = model_admin._is_changelist_request(request)  # noqa: SLF001
+    assert result is False, "UUID PK path should be detected as change view, not changelist"
 
-        # Also check app locale paths (what Django's all_locale_paths() does)
-        from django.apps import apps
 
-        app_locale_paths = []
-        for app_config in apps.get_app_configs():
-            app_locale = Path(app_config.path) / "locale"
-            if app_locale.is_dir():
-                app_locale_paths.append(str(app_locale))
+def test_uuid_pk_without_change_suffix_detected(uuid_test_setup):
+    """A URL ending with a UUID PK (no /change/ suffix) should be detected as a change view."""
+    superuser, model_admin = uuid_test_setup
+    factory = RequestFactory()
+    request = factory.get("/admin/testapp/article/550e8400-e29b-41d4-a716-446655440000/")
+    request.resolver_match = None
+    result = model_admin._is_changelist_request(request)  # noqa: SLF001
+    assert result is False, "URL ending with UUID PK should be detected as change view"
 
-        all_paths = locale_paths + app_locale_paths
 
-        assert any(Path(p).resolve() == django_admin_locale.resolve() for p in all_paths if Path(p).is_dir()), (
-            f"Django's admin locale ({django_admin_locale}) is not discoverable. "
-            f"It must be in LOCALE_PATHS or in an app's locale/ directory. "
-            f"Current discoverable paths: {all_paths}"
-        )
+def test_digit_pk_still_detected(uuid_test_setup):
+    """Numeric PKs should still be detected as change views in fallback."""
+    superuser, model_admin = uuid_test_setup
+    factory = RequestFactory()
+    request = factory.get("/admin/testapp/article/42/")
+    request.resolver_match = None
+    result = model_admin._is_changelist_request(request)  # noqa: SLF001
+    assert result is False
+
+
+def test_changelist_path_returns_true(uuid_test_setup):
+    """A changelist path should return True in fallback."""
+    superuser, model_admin = uuid_test_setup
+    factory = RequestFactory()
+    request = factory.get("/admin/testapp/article/")
+    request.resolver_match = None
+    result = model_admin._is_changelist_request(request)  # noqa: SLF001
+    assert result is True
+
+
+def test_django_admin_locale_path_is_discoverable():
+    """Issue #2: The Django admin locale directory must be in LOCALE_PATHS or discoverable."""
+    import django
+
+    django_admin_locale = Path(django.__file__).parent / "contrib" / "admin" / "locale"
+    assert django_admin_locale.is_dir(), "Django admin locale dir not found"
+
+    from django.conf import settings
+
+    locale_paths = list(getattr(settings, "LOCALE_PATHS", []))
+
+    from django.apps import apps
+
+    app_locale_paths = []
+    for app_config in apps.get_app_configs():
+        app_locale = Path(app_config.path) / "locale"
+        if app_locale.is_dir():
+            app_locale_paths.append(str(app_locale))
+
+    all_paths = locale_paths + app_locale_paths
+
+    assert any(Path(p).resolve() == django_admin_locale.resolve() for p in all_paths if Path(p).is_dir()), (
+        f"Django's admin locale ({django_admin_locale}) is not discoverable. "
+        f"It must be in LOCALE_PATHS or in an app's locale/ directory. "
+        f"Current discoverable paths: {all_paths}"
+    )

--- a/tests/test_contrib_filters.py
+++ b/tests/test_contrib_filters.py
@@ -1,369 +1,343 @@
 import datetime
 
+import pytest
 from django.contrib.admin import site as admin_site
 from django.contrib.admin.widgets import AdminRadioSelect, AdminSplitDateTime
 from django.contrib.auth.models import User
 from django.forms import CheckboxSelectMultiple, Select
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, override_settings
 
 from tests.testapp.models import Article
 
 
-class ParseDateStrTest(TestCase):
-    def test_parses_iso_format(self) -> None:
-        from django_admin_boost.admin.contrib.filters.utils import parse_date_str
+def test_parse_date_str_iso_format():
+    from django_admin_boost.admin.contrib.filters.utils import parse_date_str
 
-        result = parse_date_str("2026-01-15")
-        assert result == datetime.date(2026, 1, 15)
+    result = parse_date_str("2026-01-15")
+    assert result == datetime.date(2026, 1, 15)
 
-    def test_returns_none_for_invalid(self) -> None:
-        from django_admin_boost.admin.contrib.filters.utils import parse_date_str
 
-        result = parse_date_str("not-a-date")
-        assert result is None
+def test_parse_date_str_returns_none_for_invalid():
+    from django_admin_boost.admin.contrib.filters.utils import parse_date_str
 
-    @override_settings(DATE_INPUT_FORMATS=["%d/%m/%Y", "%Y-%m-%d"])
-    def test_uses_settings_formats(self) -> None:
-        from django_admin_boost.admin.contrib.filters.utils import parse_date_str
+    result = parse_date_str("not-a-date")
+    assert result is None
 
-        result = parse_date_str("15/01/2026")
-        assert result == datetime.date(2026, 1, 15)
 
+@override_settings(DATE_INPUT_FORMATS=["%d/%m/%Y", "%Y-%m-%d"])
+def test_parse_date_str_uses_settings_formats():
+    from django_admin_boost.admin.contrib.filters.utils import parse_date_str
 
-class ParseDateTimeStrTest(TestCase):
-    def test_parses_iso_format(self) -> None:
-        from django_admin_boost.admin.contrib.filters.utils import parse_datetime_str
+    result = parse_date_str("15/01/2026")
+    assert result == datetime.date(2026, 1, 15)
 
-        result = parse_datetime_str("2026-01-15 10:30:00")
-        assert result == datetime.datetime(2026, 1, 15, 10, 30, 0)  # noqa: DTZ001
 
-    def test_returns_none_for_invalid(self) -> None:
-        from django_admin_boost.admin.contrib.filters.utils import parse_datetime_str
+def test_parse_datetime_str_iso_format():
+    from django_admin_boost.admin.contrib.filters.utils import parse_datetime_str
 
-        result = parse_datetime_str("not-a-datetime")
-        assert result is None
+    result = parse_datetime_str("2026-01-15 10:30:00")
+    assert result == datetime.datetime(2026, 1, 15, 10, 30, 0)  # noqa: DTZ001
 
 
-class SearchFormTest(TestCase):
-    def test_creates_text_field(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import SearchForm
+def test_parse_datetime_str_returns_none_for_invalid():
+    from django_admin_boost.admin.contrib.filters.utils import parse_datetime_str
 
-        form = SearchForm(name="q", label="Search", data={"q": "test"})
-        assert "q" in form.fields
-        assert form.fields["q"].required is False
+    result = parse_datetime_str("not-a-datetime")
+    assert result is None
 
 
-class CheckboxFormTest(TestCase):
-    def test_creates_multiple_choice_field(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import CheckboxForm
+def test_search_form_creates_text_field():
+    from django_admin_boost.admin.contrib.filters.forms import SearchForm
 
-        form = CheckboxForm(
-            name="status",
-            label="By status",
-            choices=[("draft", "Draft"), ("published", "Published")],
-            data={"status": ["draft"]},
-        )
-        assert "status" in form.fields
-        assert isinstance(form.fields["status"].widget, CheckboxSelectMultiple)
+    form = SearchForm(name="q", label="Search", data={"q": "test"})
+    assert "q" in form.fields
+    assert form.fields["q"].required is False
 
 
-class RadioFormTest(TestCase):
-    def test_creates_choice_field(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import RadioForm
+def test_checkbox_form_creates_multiple_choice_field():
+    from django_admin_boost.admin.contrib.filters.forms import CheckboxForm
 
-        form = RadioForm(
-            name="status",
-            label="By status",
-            choices=[("", "All"), ("draft", "Draft")],
-            data={"status": ""},
-        )
-        assert "status" in form.fields
-        assert isinstance(form.fields["status"].widget, AdminRadioSelect)
+    form = CheckboxForm(
+        name="status",
+        label="By status",
+        choices=[("draft", "Draft"), ("published", "Published")],
+        data={"status": ["draft"]},
+    )
+    assert "status" in form.fields
+    assert isinstance(form.fields["status"].widget, CheckboxSelectMultiple)
 
 
-class DropdownFormTest(TestCase):
-    def test_creates_select_field(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import DropdownForm
+def test_radio_form_creates_choice_field():
+    from django_admin_boost.admin.contrib.filters.forms import RadioForm
 
-        form = DropdownForm(
-            name="category",
-            label="By category",
-            choices=[("", "All"), ("1", "News")],
-            data={"category": ""},
-        )
-        assert "category" in form.fields
-        assert isinstance(form.fields["category"].widget, Select)
+    form = RadioForm(
+        name="status",
+        label="By status",
+        choices=[("", "All"), ("draft", "Draft")],
+        data={"status": ""},
+    )
+    assert "status" in form.fields
+    assert isinstance(form.fields["status"].widget, AdminRadioSelect)
 
 
-class RangeNumericFormTest(TestCase):
-    def test_creates_from_and_to_fields(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import RangeNumericForm
+def test_dropdown_form_creates_select_field():
+    from django_admin_boost.admin.contrib.filters.forms import DropdownForm
 
-        form = RangeNumericForm(name="price", data={})
-        assert "price_from" in form.fields
-        assert "price_to" in form.fields
+    form = DropdownForm(
+        name="category",
+        label="By category",
+        choices=[("", "All"), ("1", "News")],
+        data={"category": ""},
+    )
+    assert "category" in form.fields
+    assert isinstance(form.fields["category"].widget, Select)
 
 
-class SingleNumericFormTest(TestCase):
-    def test_creates_numeric_field(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import SingleNumericForm
+def test_range_numeric_form_creates_from_and_to_fields():
+    from django_admin_boost.admin.contrib.filters.forms import RangeNumericForm
 
-        form = SingleNumericForm(name="priority", data={})
-        assert "priority" in form.fields
+    form = RangeNumericForm(name="price", data={})
+    assert "price_from" in form.fields
+    assert "price_to" in form.fields
 
 
-class RangeDateFormTest(TestCase):
-    def test_creates_date_from_and_to(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import RangeDateForm
+def test_single_numeric_form_creates_numeric_field():
+    from django_admin_boost.admin.contrib.filters.forms import SingleNumericForm
 
-        form = RangeDateForm(name="publish_date", data={})
-        assert "publish_date_from" in form.fields
-        assert "publish_date_to" in form.fields
+    form = SingleNumericForm(name="priority", data={})
+    assert "priority" in form.fields
 
 
-class RangeDateTimeFormTest(TestCase):
-    def test_creates_datetime_from_and_to(self) -> None:
-        from django_admin_boost.admin.contrib.filters.forms import RangeDateTimeForm
+def test_range_date_form_creates_date_from_and_to():
+    from django_admin_boost.admin.contrib.filters.forms import RangeDateForm
 
-        form = RangeDateTimeForm(name="created_at", data={})
-        assert "created_at_from" in form.fields
-        assert "created_at_to" in form.fields
-        assert isinstance(form.fields["created_at_from"].widget, AdminSplitDateTime)
+    form = RangeDateForm(name="publish_date", data={})
+    assert "publish_date_from" in form.fields
+    assert "publish_date_to" in form.fields
 
 
-class ValueMixinTest(TestCase):
-    def test_returns_first_item_from_list(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.mixins import ValueMixin
+def test_range_datetime_form_creates_datetime_from_and_to():
+    from django_admin_boost.admin.contrib.filters.forms import RangeDateTimeForm
 
-        obj = ValueMixin()
-        obj.lookup_val = ["foo", "bar"]
-        assert obj.value() == "foo"
+    form = RangeDateTimeForm(name="created_at", data={})
+    assert "created_at_from" in form.fields
+    assert "created_at_to" in form.fields
+    assert isinstance(form.fields["created_at_from"].widget, AdminSplitDateTime)
 
-    def test_returns_none_when_no_value(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.mixins import ValueMixin
 
-        obj = ValueMixin()
-        obj.lookup_val = None
-        assert obj.value() is None
+def test_value_mixin_returns_first_item_from_list():
+    from django_admin_boost.admin.contrib.filters.admin.mixins import ValueMixin
 
+    obj = ValueMixin()
+    obj.lookup_val = ["foo", "bar"]
+    assert obj.value() == "foo"
 
-class MultiValueMixinTest(TestCase):
-    def test_returns_list(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.mixins import MultiValueMixin
 
-        obj = MultiValueMixin()
-        obj.lookup_val = ["foo", "bar"]
-        assert obj.value() == ["foo", "bar"]
+def test_value_mixin_returns_none_when_no_value():
+    from django_admin_boost.admin.contrib.filters.admin.mixins import ValueMixin
 
+    obj = ValueMixin()
+    obj.lookup_val = None
+    assert obj.value() is None
 
-class RangeNumericMixinTest(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        Article.objects.create(title="Cheap", priority=10)
-        Article.objects.create(title="Expensive", priority=90)
 
-    def test_filters_queryset_by_range(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.mixins import RangeNumericMixin
-
-        mixin = RangeNumericMixin.__new__(RangeNumericMixin)
-        mixin.parameter_name = "priority"
-        mixin.used_parameters = {"priority_from": "10", "priority_to": "50"}
-        qs = Article.objects.all()
-        result = mixin.queryset(None, qs)
-        assert result.count() == 1
-        assert result.first().title == "Cheap"
-
-    def test_expected_parameters(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.mixins import RangeNumericMixin
-
-        mixin = RangeNumericMixin.__new__(RangeNumericMixin)
-        mixin.parameter_name = "priority"
-        assert mixin.expected_parameters() == ["priority_from", "priority_to"]
-
-
-class TextFilterTest(TestCase):
-    def test_has_output_returns_true(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin.text_filters import TextFilter
-
-        class TitleFilter(TextFilter):
-            title = "Title"
-            parameter_name = "title__icontains"
-
-            def lookups(self, request, model_admin):
-                return ()
-
-            def queryset(self, request, queryset):
-                if self.value():
-                    return queryset.filter(title__icontains=self.value())
-                return queryset
-
-        f = TitleFilter(None, {}, Article, None)
-        assert f.has_output() is True
-
-
-class FieldTextFilterTest(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        Article.objects.create(title="Hello World")
-        Article.objects.create(title="Goodbye World")
-        cls.superuser = User.objects.create_superuser(
-            username="admin_text",
-            password="password",
-        )
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-
-    def test_filters_by_icontains(self) -> None:
-        from django_admin_boost.admin import ModelAdmin
-        from django_admin_boost.admin.contrib.filters.admin.text_filters import FieldTextFilter
-
-        class ArticleAdmin(ModelAdmin):
-            list_filter = [("title", FieldTextFilter)]
-
-        ma = ArticleAdmin(Article, admin_site)
-        request = self.factory.get(
-            "/admin/testapp/article/",
-            {"title__icontains": "Hello"},
-        )
-        request.user = self.superuser
-        changelist = ma.get_changelist_instance(request)
-        qs = changelist.get_queryset(request)
-        assert qs.count() == 1
-        assert qs.first().title == "Hello World"
-
-
-class RangeNumericFilterTest(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        Article.objects.create(title="Low", priority=5)
-        Article.objects.create(title="Mid", priority=50)
-        Article.objects.create(title="High", priority=95)
-        cls.superuser = User.objects.create_superuser(
-            username="admin_numeric",
-            password="password",
-        )
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-
-    def test_filters_by_range(self) -> None:
-        from django_admin_boost.admin import ModelAdmin
-        from django_admin_boost.admin.contrib.filters.admin.numeric_filters import (
-            RangeNumericFilter,
-        )
-
-        class ArticleAdmin(ModelAdmin):
-            list_filter = [("priority", RangeNumericFilter)]
-
-        ma = ArticleAdmin(Article, admin_site)
-        request = self.factory.get(
-            "/admin/testapp/article/",
-            {"priority_from": "10", "priority_to": "60"},
-        )
-        request.user = self.superuser
-        changelist = ma.get_changelist_instance(request)
-        qs = changelist.get_queryset(request)
-        assert qs.count() == 1
-        assert qs.first().title == "Mid"
-
-
-class SingleNumericFilterTest2(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        Article.objects.create(title="Target", priority=42)
-        Article.objects.create(title="Other", priority=99)
-        cls.superuser = User.objects.create_superuser(
-            username="admin_single",
-            password="password",
-        )
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-
-    def test_filters_exact(self) -> None:
-        from django_admin_boost.admin import ModelAdmin
-        from django_admin_boost.admin.contrib.filters.admin.numeric_filters import (
-            SingleNumericFilter,
-        )
-
-        class ArticleAdmin(ModelAdmin):
-            list_filter = [("priority", SingleNumericFilter)]
-
-        ma = ArticleAdmin(Article, admin_site)
-        request = self.factory.get("/admin/testapp/article/", {"priority": "42"})
-        request.user = self.superuser
-        changelist = ma.get_changelist_instance(request)
-        qs = changelist.get_queryset(request)
-        assert qs.count() == 1
-        assert qs.first().title == "Target"
-
-
-class RangeDateFilterTest(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        Article.objects.create(title="Old", publish_date=datetime.date(2025, 1, 1))
-        Article.objects.create(title="Recent", publish_date=datetime.date(2026, 3, 15))
-        Article.objects.create(title="Future", publish_date=datetime.date(2027, 6, 1))
-        cls.superuser = User.objects.create_superuser(
-            username="admin_date",
-            password="password",
-        )
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-
-    def test_filters_by_date_range(self) -> None:
-        from django_admin_boost.admin import ModelAdmin
-        from django_admin_boost.admin.contrib.filters.admin.datetime_filters import (
-            RangeDateFilter,
-        )
-
-        class ArticleAdmin(ModelAdmin):
-            list_filter = [("publish_date", RangeDateFilter)]
-
-        ma = ArticleAdmin(Article, admin_site)
-        request = self.factory.get(
-            "/admin/testapp/article/",
-            {"publish_date_from": "2026-01-01", "publish_date_to": "2026-12-31"},
-        )
-        request.user = self.superuser
-        changelist = ma.get_changelist_instance(request)
-        qs = changelist.get_queryset(request)
-        assert qs.count() == 1
-        assert qs.first().title == "Recent"
-
-
-class FilterImportsTest(TestCase):
-    def test_all_filters_importable(self) -> None:
-        from django_admin_boost.admin.contrib.filters.admin import (
-            AutocompleteSelectFilter,
-            AutocompleteSelectMultipleFilter,
-            BooleanRadioFilter,
-            DropdownFilter,
+def test_multi_value_mixin_returns_list():
+    from django_admin_boost.admin.contrib.filters.admin.mixins import MultiValueMixin
+
+    obj = MultiValueMixin()
+    obj.lookup_val = ["foo", "bar"]
+    assert obj.value() == ["foo", "bar"]
+
+
+@pytest.mark.django_db
+def test_range_numeric_mixin_filters_queryset_by_range():
+    from django_admin_boost.admin.contrib.filters.admin.mixins import RangeNumericMixin
+
+    Article.objects.create(title="Cheap", priority=10)
+    Article.objects.create(title="Expensive", priority=90)
+
+    mixin = RangeNumericMixin.__new__(RangeNumericMixin)
+    mixin.parameter_name = "priority"
+    mixin.used_parameters = {"priority_from": "10", "priority_to": "50"}
+    qs = Article.objects.all()
+    result = mixin.queryset(None, qs)
+    assert result.count() == 1
+    assert result.first().title == "Cheap"
+
+
+def test_range_numeric_mixin_expected_parameters():
+    from django_admin_boost.admin.contrib.filters.admin.mixins import RangeNumericMixin
+
+    mixin = RangeNumericMixin.__new__(RangeNumericMixin)
+    mixin.parameter_name = "priority"
+    assert mixin.expected_parameters() == ["priority_from", "priority_to"]
+
+
+def test_text_filter_has_output_returns_true():
+    from django_admin_boost.admin.contrib.filters.admin.text_filters import TextFilter
+
+    class TitleFilter(TextFilter):
+        title = "Title"
+        parameter_name = "title__icontains"
+
+        def lookups(self, request, model_admin):
+            return ()
+
+        def queryset(self, request, queryset):
+            if self.value():
+                return queryset.filter(title__icontains=self.value())
+            return queryset
+
+    f = TitleFilter(None, {}, Article, None)
+    assert f.has_output() is True
+
+
+@pytest.fixture
+def field_text_filter_articles(db):
+    Article.objects.create(title="Hello World")
+    Article.objects.create(title="Goodbye World")
+    return User.objects.create_superuser(username="admin_text", password="password")
+
+
+def test_field_text_filter_filters_by_icontains(field_text_filter_articles):
+    from django_admin_boost.admin import ModelAdmin
+    from django_admin_boost.admin.contrib.filters.admin.text_filters import FieldTextFilter
+
+    superuser = field_text_filter_articles
+
+    class ArticleAdmin(ModelAdmin):
+        list_filter = [("title", FieldTextFilter)]
+
+    ma = ArticleAdmin(Article, admin_site)
+    request = RequestFactory().get(
+        "/admin/testapp/article/",
+        {"title__icontains": "Hello"},
+    )
+    request.user = superuser
+    changelist = ma.get_changelist_instance(request)
+    qs = changelist.get_queryset(request)
+    assert qs.count() == 1
+    assert qs.first().title == "Hello World"
+
+
+@pytest.fixture
+def range_numeric_articles(db):
+    Article.objects.create(title="Low", priority=5)
+    Article.objects.create(title="Mid", priority=50)
+    Article.objects.create(title="High", priority=95)
+    return User.objects.create_superuser(username="admin_numeric", password="password")
+
+
+def test_range_numeric_filter_filters_by_range(range_numeric_articles):
+    from django_admin_boost.admin import ModelAdmin
+    from django_admin_boost.admin.contrib.filters.admin.numeric_filters import (
+        RangeNumericFilter,
+    )
+
+    superuser = range_numeric_articles
+
+    class ArticleAdmin(ModelAdmin):
+        list_filter = [("priority", RangeNumericFilter)]
+
+    ma = ArticleAdmin(Article, admin_site)
+    request = RequestFactory().get(
+        "/admin/testapp/article/",
+        {"priority_from": "10", "priority_to": "60"},
+    )
+    request.user = superuser
+    changelist = ma.get_changelist_instance(request)
+    qs = changelist.get_queryset(request)
+    assert qs.count() == 1
+    assert qs.first().title == "Mid"
+
+
+@pytest.fixture
+def single_numeric_articles(db):
+    Article.objects.create(title="Target", priority=42)
+    Article.objects.create(title="Other", priority=99)
+    return User.objects.create_superuser(username="admin_single", password="password")
+
+
+def test_single_numeric_filter_filters_exact(single_numeric_articles):
+    from django_admin_boost.admin import ModelAdmin
+    from django_admin_boost.admin.contrib.filters.admin.numeric_filters import (
+        SingleNumericFilter,
+    )
+
+    superuser = single_numeric_articles
+
+    class ArticleAdmin(ModelAdmin):
+        list_filter = [("priority", SingleNumericFilter)]
+
+    ma = ArticleAdmin(Article, admin_site)
+    request = RequestFactory().get("/admin/testapp/article/", {"priority": "42"})
+    request.user = superuser
+    changelist = ma.get_changelist_instance(request)
+    qs = changelist.get_queryset(request)
+    assert qs.count() == 1
+    assert qs.first().title == "Target"
+
+
+@pytest.fixture
+def range_date_articles(db):
+    Article.objects.create(title="Old", publish_date=datetime.date(2025, 1, 1))
+    Article.objects.create(title="Recent", publish_date=datetime.date(2026, 3, 15))
+    Article.objects.create(title="Future", publish_date=datetime.date(2027, 6, 1))
+    return User.objects.create_superuser(username="admin_date", password="password")
+
+
+def test_range_date_filter_filters_by_date_range(range_date_articles):
+    from django_admin_boost.admin import ModelAdmin
+    from django_admin_boost.admin.contrib.filters.admin.datetime_filters import (
+        RangeDateFilter,
+    )
+
+    superuser = range_date_articles
+
+    class ArticleAdmin(ModelAdmin):
+        list_filter = [("publish_date", RangeDateFilter)]
+
+    ma = ArticleAdmin(Article, admin_site)
+    request = RequestFactory().get(
+        "/admin/testapp/article/",
+        {"publish_date_from": "2026-01-01", "publish_date_to": "2026-12-31"},
+    )
+    request.user = superuser
+    changelist = ma.get_changelist_instance(request)
+    qs = changelist.get_queryset(request)
+    assert qs.count() == 1
+    assert qs.first().title == "Recent"
+
+
+def test_all_filters_importable():
+    from django_admin_boost.admin.contrib.filters.admin import (
+        AutocompleteSelectFilter,
+        AutocompleteSelectMultipleFilter,
+        BooleanRadioFilter,
+        DropdownFilter,
+        FieldTextFilter,
+        RadioFilter,
+        RangeDateFilter,
+        RangeDateTimeFilter,
+        RangeNumericFilter,
+        SingleNumericFilter,
+        SliderNumericFilter,
+        TextFilter,
+    )
+
+    assert all(
+        [
+            TextFilter,
             FieldTextFilter,
             RadioFilter,
+            BooleanRadioFilter,
             RangeDateFilter,
             RangeDateTimeFilter,
-            RangeNumericFilter,
             SingleNumericFilter,
+            RangeNumericFilter,
             SliderNumericFilter,
-            TextFilter,
-        )
-
-        assert all(
-            [
-                TextFilter,
-                FieldTextFilter,
-                RadioFilter,
-                BooleanRadioFilter,
-                RangeDateFilter,
-                RangeDateTimeFilter,
-                SingleNumericFilter,
-                RangeNumericFilter,
-                SliderNumericFilter,
-                DropdownFilter,
-                AutocompleteSelectFilter,
-                AutocompleteSelectMultipleFilter,
-            ],
-        )
+            DropdownFilter,
+            AutocompleteSelectFilter,
+            AutocompleteSelectMultipleFilter,
+        ],
+    )

--- a/tests/test_contrib_forms.py
+++ b/tests/test_contrib_forms.py
@@ -1,57 +1,57 @@
-from django.test import TestCase
+def test_array_widget_decompress_list():
+    from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
+
+    widget = ArrayWidget()
+    assert widget.decompress(["a", "b"]) == ["a", "b"]
 
 
-class ArrayWidgetTest(TestCase):
-    def test_decompress_list(self) -> None:
-        from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
+def test_array_widget_decompress_csv_string():
+    from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
 
-        widget = ArrayWidget()
-        assert widget.decompress(["a", "b"]) == ["a", "b"]
-
-    def test_decompress_csv_string(self) -> None:
-        from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
-
-        widget = ArrayWidget()
-        assert widget.decompress("a,b,c") == ["a", "b", "c"]
-
-    def test_decompress_none(self) -> None:
-        from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
-
-        widget = ArrayWidget()
-        assert widget.decompress(None) == []
-
-    def test_value_from_datadict_filters_empty(self) -> None:
-        from django.http import QueryDict
-
-        from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
-
-        widget = ArrayWidget()
-        data = QueryDict(mutable=True)
-        data.setlist("tags", ["foo", "", "bar"])
-        result = widget.value_from_datadict(data, {}, "tags")
-        assert result == ["foo", "bar"]
-
-    def test_custom_widget_class(self) -> None:
-        from django.forms import NumberInput
-
-        from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
-
-        widget = ArrayWidget(widget_class=NumberInput)
-        instance = widget.get_widget_instance()
-        assert isinstance(instance, NumberInput)
+    widget = ArrayWidget()
+    assert widget.decompress("a,b,c") == ["a", "b", "c"]
 
 
-class WysiwygWidgetTest(TestCase):
-    def test_template_name(self) -> None:
-        from django_admin_boost.admin.contrib.forms.widgets import WysiwygWidget
+def test_array_widget_decompress_none():
+    from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
 
-        widget = WysiwygWidget()
-        assert widget.template_name == "admin/forms/wysiwyg.html"
+    widget = ArrayWidget()
+    assert widget.decompress(None) == []
 
-    def test_media_includes_trix(self) -> None:
-        from django_admin_boost.admin.contrib.forms.widgets import WysiwygWidget
 
-        widget = WysiwygWidget()
-        media_str = str(widget.media)
-        assert "trix.js" in media_str
-        assert "trix.css" in media_str
+def test_array_widget_value_from_datadict_filters_empty():
+    from django.http import QueryDict
+
+    from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
+
+    widget = ArrayWidget()
+    data = QueryDict(mutable=True)
+    data.setlist("tags", ["foo", "", "bar"])
+    result = widget.value_from_datadict(data, {}, "tags")
+    assert result == ["foo", "bar"]
+
+
+def test_array_widget_custom_widget_class():
+    from django.forms import NumberInput
+
+    from django_admin_boost.admin.contrib.forms.widgets import ArrayWidget
+
+    widget = ArrayWidget(widget_class=NumberInput)
+    instance = widget.get_widget_instance()
+    assert isinstance(instance, NumberInput)
+
+
+def test_wysiwyg_widget_template_name():
+    from django_admin_boost.admin.contrib.forms.widgets import WysiwygWidget
+
+    widget = WysiwygWidget()
+    assert widget.template_name == "admin/forms/wysiwyg.html"
+
+
+def test_wysiwyg_widget_media_includes_trix():
+    from django_admin_boost.admin.contrib.forms.widgets import WysiwygWidget
+
+    widget = WysiwygWidget()
+    media_str = str(widget.media)
+    assert "trix.js" in media_str
+    assert "trix.css" in media_str

--- a/tests/test_contrib_inlines.py
+++ b/tests/test_contrib_inlines.py
@@ -2,77 +2,79 @@ import pytest
 from django.contrib.admin import site as admin_site
 from django.contrib.auth.models import User
 from django.db.models import QuerySet
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 
 from tests.testapp.models import Article, Category
 
 
-class NonrelatedInlineMixinTest(TestCase):
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.category = Category.objects.create(name="News")
-        cls.superuser = User.objects.create_superuser(
-            username="admin_inline",
-            password="password",
-        )
-
-    def test_get_form_queryset_is_required(self) -> None:
-        from django_admin_boost.admin.contrib.inlines.admin import NonrelatedStackedInline
-
-        class BadInline(NonrelatedStackedInline):
-            model = Category
-            fields = ["name"]
-
-        inline = BadInline(Article, admin_site)
-        request = RequestFactory().get("/admin/")
-        request.user = self.superuser
-        with pytest.raises(NotImplementedError):
-            inline.get_formset(request, obj=self.category)
-
-    def test_formset_with_queryset(self) -> None:
-        from django_admin_boost.admin.contrib.inlines.admin import NonrelatedStackedInline
-
-        class CategoryInline(NonrelatedStackedInline):
-            model = Category
-            fields = ["name"]
-
-            def get_form_queryset(self, obj) -> QuerySet:
-                return Category.objects.filter(pk=obj.pk)
-
-            def save_new_instance(self, parent, instance) -> None:
-                instance.save()
-
-        inline = CategoryInline(Article, admin_site)
-        request = RequestFactory().get("/admin/")
-        request.user = self.superuser
-        formset_cls = inline.get_formset(request, obj=self.category)
-        assert formset_cls.provided_queryset.count() == 1
+@pytest.fixture
+def inline_setup(db):
+    category = Category.objects.create(name="News")
+    superuser = User.objects.create_superuser(username="admin_inline", password="password")
+    return category, superuser
 
 
-class NonrelatedModelAdminChecksTest(TestCase):
-    def test_skips_relation_check(self) -> None:
-        from django_admin_boost.admin.contrib.inlines.checks import NonrelatedModelAdminChecks
+def test_get_form_queryset_is_required(inline_setup):
+    from django_admin_boost.admin.contrib.inlines.admin import NonrelatedStackedInline
 
-        checker = NonrelatedModelAdminChecks()
-        assert checker._check_relation(None, None) == []  # noqa: SLF001
+    category, superuser = inline_setup
 
-    def test_skips_exclude_of_parent_model_check(self) -> None:
-        from django_admin_boost.admin.contrib.inlines.checks import NonrelatedModelAdminChecks
+    class BadInline(NonrelatedStackedInline):
+        model = Category
+        fields = ["name"]
 
-        checker = NonrelatedModelAdminChecks()
-        assert checker._check_exclude_of_parent_model(None, None) == []  # noqa: SLF001
+    inline = BadInline(Article, admin_site)
+    request = RequestFactory().get("/admin/")
+    request.user = superuser
+    with pytest.raises(NotImplementedError):
+        inline.get_formset(request, obj=category)
 
 
-class NonrelatedInlineFormSetTest(TestCase):
-    def test_default_prefix(self) -> None:
-        from django_admin_boost.admin.contrib.inlines.forms import (
-            nonrelated_inline_formset_factory,
-        )
+def test_formset_with_queryset(inline_setup):
+    from django_admin_boost.admin.contrib.inlines.admin import NonrelatedStackedInline
 
-        formset_cls = nonrelated_inline_formset_factory(
-            Category,
-            queryset=Category.objects.none(),
-            save_new_instance=lambda p, i: None,
-            fields=["name"],
-        )
-        assert formset_cls.get_default_prefix() == "testapp-category"
+    category, superuser = inline_setup
+
+    class CategoryInline(NonrelatedStackedInline):
+        model = Category
+        fields = ["name"]
+
+        def get_form_queryset(self, obj) -> QuerySet:
+            return Category.objects.filter(pk=obj.pk)
+
+        def save_new_instance(self, parent, instance) -> None:
+            instance.save()
+
+    inline = CategoryInline(Article, admin_site)
+    request = RequestFactory().get("/admin/")
+    request.user = superuser
+    formset_cls = inline.get_formset(request, obj=category)
+    assert formset_cls.provided_queryset.count() == 1
+
+
+def test_skips_relation_check():
+    from django_admin_boost.admin.contrib.inlines.checks import NonrelatedModelAdminChecks
+
+    checker = NonrelatedModelAdminChecks()
+    assert checker._check_relation(None, None) == []  # noqa: SLF001
+
+
+def test_skips_exclude_of_parent_model_check():
+    from django_admin_boost.admin.contrib.inlines.checks import NonrelatedModelAdminChecks
+
+    checker = NonrelatedModelAdminChecks()
+    assert checker._check_exclude_of_parent_model(None, None) == []  # noqa: SLF001
+
+
+def test_nonrelated_inline_formset_default_prefix():
+    from django_admin_boost.admin.contrib.inlines.forms import (
+        nonrelated_inline_formset_factory,
+    )
+
+    formset_cls = nonrelated_inline_formset_factory(
+        Category,
+        queryset=Category.objects.none(),
+        save_new_instance=lambda p, i: None,
+        fields=["name"],
+    )
+    assert formset_cls.get_default_prefix() == "testapp-category"

--- a/tests/test_jinja2_admin_views.py
+++ b/tests/test_jinja2_admin_views.py
@@ -1,7 +1,8 @@
 """Integration smoke tests: render admin pages via Jinja2 backend."""
 
+import pytest
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from tests.testapp.models import Article
 
@@ -35,224 +36,208 @@ JINJA2_TEMPLATES = [
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2LoginTest(TestCase):
-    def test_login_page_renders(self):
-        response = self.client.get("/admin/login/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "login-form" in content
-        assert 'type="submit"' in content
-
-    def test_login_page_has_csrf(self):
-        response = self.client.get("/admin/login/")
-        content = response.content.decode()
-        assert "csrfmiddlewaretoken" in content
-
-    def test_invalid_login_shows_errors(self):
-        response = self.client.post(
-            "/admin/login/",
-            {"username": "wrong", "password": "wrong"},
-        )
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "errornote" in content
+def test_login_page_renders(client):
+    response = client.get("/admin/login/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "login-form" in content
+    assert 'type="submit"' in content
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2DashboardTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
-
-    def test_index_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "recent-actions-module" in content
-        assert "content-main" in content
-
-    def test_index_shows_app_list(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/")
-        content = response.content.decode()
-        assert "article" in content.lower()
-
-    def test_app_index_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/")
-        assert response.status_code == 200
-
-    def test_auth_app_index_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/auth/")
-        assert response.status_code == 200
+def test_login_page_has_csrf(client):
+    response = client.get("/admin/login/")
+    content = response.content.decode()
+    assert "csrfmiddlewaretoken" in content
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2HeaderTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
+def test_invalid_login_shows_errors(client, db):
+    response = client.post(
+        "/admin/login/",
+        {"username": "wrong", "password": "wrong"},
+    )
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "errornote" in content
 
-    def test_header_shows_username(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/")
-        content = response.content.decode()
-        assert "admin" in content
 
-    def test_header_has_logout_form(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/")
-        content = response.content.decode()
-        assert "logout-form" in content
-
-    def test_theme_toggle_present(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/")
-        content = response.content.decode()
-        assert "theme-toggle" in content
+@pytest.fixture
+def jinja2_superuser(db):
+    return User.objects.create_superuser(username="admin", password="password")
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2ChangelistTest(TestCase):
-    """Test changelist views render via Jinja2."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
-        for i in range(5):
-            Article.objects.create(
-                title=f"Article {i}",
-                status="published" if i % 2 == 0 else "draft",
-            )
-
-    def test_changelist_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "Article 0" in content
-
-    def test_changelist_search(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/?q=Article+3")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "Article 3" in content
-
-    def test_changelist_has_pagination(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/")
-        assert response.status_code == 200
-
-    def test_user_changelist_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/auth/user/")
-        assert response.status_code == 200
-
-    def test_group_changelist_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/auth/group/")
-        assert response.status_code == 200
+def test_index_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "recent-actions-module" in content
+    assert "content-main" in content
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2ChangeFormTest(TestCase):
-    """Test add/change form views render via Jinja2."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
-        cls.article = Article.objects.create(title="Test Article", status="draft")
-
-    def test_add_form_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/testapp/article/add/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "csrf" in content.lower() or "csrfmiddlewaretoken" in content
-
-    def test_change_form_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/change/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "Test Article" in content
-
-    def test_user_add_form_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/auth/user/add/")
-        assert response.status_code == 200
-
-    def test_user_change_form_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get(f"/admin/auth/user/{self.superuser.pk}/change/")
-        assert response.status_code == 200
+def test_index_shows_app_list(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/")
+    content = response.content.decode()
+    assert "article" in content.lower()
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2DeleteTest(TestCase):
-    """Test delete confirmation views render via Jinja2."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
-        cls.article = Article.objects.create(title="To Delete", status="draft")
-
-    def test_delete_confirmation_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/delete/")
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "To Delete" in content
+def test_app_index_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/testapp/")
+    assert response.status_code == 200
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2HistoryTest(TestCase):
-    """Test object history view renders via Jinja2."""
-
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
-        )
-        cls.article = Article.objects.create(title="History Test", status="draft")
-
-    def test_history_view_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get(f"/admin/testapp/article/{self.article.pk}/history/")
-        assert response.status_code == 200
+def test_auth_app_index_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/auth/")
+    assert response.status_code == 200
 
 
 @override_settings(TEMPLATES=JINJA2_TEMPLATES)
-class Jinja2PasswordChangeTest(TestCase):
-    """Test password change view renders via Jinja2."""
+def test_header_shows_username(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/")
+    content = response.content.decode()
+    assert "admin" in content
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(
-            username="admin",
-            password="password",
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_header_has_logout_form(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/")
+    content = response.content.decode()
+    assert "logout-form" in content
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_theme_toggle_present(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/")
+    content = response.content.decode()
+    assert "theme-toggle" in content
+
+
+@pytest.fixture
+def jinja2_articles(db):
+    return [
+        Article.objects.create(
+            title=f"Article {i}",
+            status="published" if i % 2 == 0 else "draft",
         )
+        for i in range(5)
+    ]
 
-    def test_password_change_renders(self):
-        self.client.force_login(self.superuser)
-        response = self.client.get("/admin/password_change/")
-        assert response.status_code == 200
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_changelist_renders(client, jinja2_superuser, jinja2_articles):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/testapp/article/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Article 0" in content
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_changelist_search(client, jinja2_superuser, jinja2_articles):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/testapp/article/?q=Article+3")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Article 3" in content
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_changelist_has_pagination(client, jinja2_superuser, jinja2_articles):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/testapp/article/")
+    assert response.status_code == 200
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_user_changelist_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/auth/user/")
+    assert response.status_code == 200
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_group_changelist_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/auth/group/")
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def jinja2_article(db):
+    return Article.objects.create(title="Test Article", status="draft")
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_add_form_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/testapp/article/add/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "csrf" in content.lower() or "csrfmiddlewaretoken" in content
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_change_form_renders(client, jinja2_superuser, jinja2_article):
+    client.force_login(jinja2_superuser)
+    response = client.get(f"/admin/testapp/article/{jinja2_article.pk}/change/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Test Article" in content
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_user_add_form_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/auth/user/add/")
+    assert response.status_code == 200
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_user_change_form_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get(f"/admin/auth/user/{jinja2_superuser.pk}/change/")
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def article_to_delete(db):
+    return Article.objects.create(title="To Delete", status="draft")
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_delete_confirmation_renders(client, jinja2_superuser, article_to_delete):
+    client.force_login(jinja2_superuser)
+    response = client.get(f"/admin/testapp/article/{article_to_delete.pk}/delete/")
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "To Delete" in content
+
+
+@pytest.fixture
+def article_for_history(db):
+    return Article.objects.create(title="History Test", status="draft")
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_history_view_renders(client, jinja2_superuser, article_for_history):
+    client.force_login(jinja2_superuser)
+    response = client.get(f"/admin/testapp/article/{article_for_history.pk}/history/")
+    assert response.status_code == 200
+
+
+@override_settings(TEMPLATES=JINJA2_TEMPLATES)
+def test_password_change_renders(client, jinja2_superuser):
+    client.force_login(jinja2_superuser)
+    response = client.get("/admin/password_change/")
+    assert response.status_code == 200

--- a/tests/test_jinja2_parity.py
+++ b/tests/test_jinja2_parity.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 from bs4 import BeautifulSoup
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import override_settings
 
 from tests.testapp.models import Article, Category
 
@@ -195,146 +196,134 @@ def _render_with(client, path: str, templates: list) -> str:
         return response.content.decode()
 
 
-class RenderParityMixin:
-    """Mixin providing assert_parity() that compares both Jinja2 and DTL against Django's originals."""
+def assert_parity(client, path: str) -> None:
+    """Assert that both our Jinja2 AND DTL renders match Django's original."""
+    baseline = _render_with(client, path, DJANGO_ORIGINAL_DTL)
+    jinja2_html = _render_with(client, path, JINJA2_ADMINX)
+    dtl_html = _render_with(client, path, DTL_ADMINX)
 
-    def assert_parity(self, path: str) -> None:
-        """Assert that both our Jinja2 AND DTL renders match Django's original."""
-        baseline = _render_with(self.client, path, DJANGO_ORIGINAL_DTL)  # type: ignore[attr-defined]
-        jinja2_html = _render_with(self.client, path, JINJA2_ADMINX)  # type: ignore[attr-defined]
-        dtl_html = _render_with(self.client, path, DTL_ADMINX)  # type: ignore[attr-defined]
+    all_diffs = []
 
-        all_diffs = []
+    jinja2_diffs = compare_renders(jinja2_html, baseline, label="jinja2")
+    if jinja2_diffs:
+        all_diffs.append("Jinja2 vs Django original:")
+        all_diffs.extend(f"  - {d}" for d in jinja2_diffs)
 
-        jinja2_diffs = compare_renders(jinja2_html, baseline, label="jinja2")
-        if jinja2_diffs:
-            all_diffs.append("Jinja2 vs Django original:")
-            all_diffs.extend(f"  - {d}" for d in jinja2_diffs)
+    dtl_diffs = compare_renders(dtl_html, baseline, label="dtl")
+    if dtl_diffs:
+        all_diffs.append("DTL copy vs Django original:")
+        all_diffs.extend(f"  - {d}" for d in dtl_diffs)
 
-        dtl_diffs = compare_renders(dtl_html, baseline, label="dtl")
-        if dtl_diffs:
-            all_diffs.append("DTL copy vs Django original:")
-            all_diffs.extend(f"  - {d}" for d in dtl_diffs)
-
-        if all_diffs:
-            msg = f"Render parity failed for {path}:\n" + "\n".join(all_diffs)
-            raise AssertionError(msg)
+    if all_diffs:
+        msg = f"Render parity failed for {path}:\n" + "\n".join(all_diffs)
+        raise AssertionError(msg)
 
 
 # --- Tests ---
 
 
-class LoginParityTest(RenderParityMixin, TestCase):
-    def test_login_page(self):
-        self.assert_parity("/admin/login/")
+def test_login_page(client):
+    assert_parity(client, "/admin/login/")
 
 
-class DashboardParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-
-    def setUp(self):
-        self.client.force_login(self.superuser)
-
-    def test_index(self):
-        self.assert_parity("/admin/")
-
-    def test_app_index(self):
-        self.assert_parity("/admin/testapp/")
-
-    def test_auth_app_index(self):
-        self.assert_parity("/admin/auth/")
+@pytest.fixture
+def parity_superuser(db):
+    return User.objects.create_superuser(username="admin", password="password")
 
 
-class ChangelistParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-        cat = Category.objects.create(name="Tech")
-        for i in range(5):
-            Article.objects.create(
-                title=f"Article {i}",
-                slug=f"article-{i}",
-                status="published" if i % 2 == 0 else "draft",
-                is_featured=i == 0,
-                priority=i,
-                category=cat if i % 2 == 0 else None,
-            )
-
-    def setUp(self):
-        self.client.force_login(self.superuser)
-
-    def test_changelist(self):
-        self.assert_parity("/admin/testapp/article/")
-
-    def test_changelist_search(self):
-        self.assert_parity("/admin/testapp/article/?q=Article")
-
-    def test_changelist_filter(self):
-        self.assert_parity("/admin/testapp/article/?status__exact=published")
-
-    def test_changelist_boolean_filter(self):
-        self.assert_parity("/admin/testapp/article/?is_featured__exact=1")
+def test_dashboard_index(client, parity_superuser):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/")
 
 
-class ChangeFormParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-        cat = Category.objects.create(name="Science")
-        cls.article = Article.objects.create(
-            title="Parity Test",
-            slug="parity-test",
-            status="draft",
-            category=cat,
-            is_featured=True,
-            priority=5,
+def test_dashboard_app_index(client, parity_superuser):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/")
+
+
+def test_dashboard_auth_app_index(client, parity_superuser):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/auth/")
+
+
+@pytest.fixture
+def parity_articles(db):
+    cat = Category.objects.create(name="Tech")
+    for i in range(5):
+        Article.objects.create(
+            title=f"Article {i}",
+            slug=f"article-{i}",
+            status="published" if i % 2 == 0 else "draft",
+            is_featured=i == 0,
+            priority=i,
+            category=cat if i % 2 == 0 else None,
         )
-
-    def setUp(self):
-        self.client.force_login(self.superuser)
-
-    def test_add_form(self):
-        self.assert_parity("/admin/testapp/article/add/")
-
-    def test_change_form(self):
-        self.assert_parity(f"/admin/testapp/article/{self.article.pk}/change/")
+    return cat
 
 
-class DeleteParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-        cls.article = Article.objects.create(title="Delete Me", slug="delete-me", status="draft")
-
-    def setUp(self):
-        self.client.force_login(self.superuser)
-
-    def test_delete_confirmation(self):
-        self.assert_parity(f"/admin/testapp/article/{self.article.pk}/delete/")
+def test_changelist(client, parity_superuser, parity_articles):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/article/")
 
 
-class HistoryParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-        cls.article = Article.objects.create(title="History Test", slug="history-test", status="draft")
-
-    def setUp(self):
-        self.client.force_login(self.superuser)
-
-    def test_history(self):
-        self.assert_parity(f"/admin/testapp/article/{self.article.pk}/history/")
+def test_changelist_search(client, parity_superuser, parity_articles):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/article/?q=Article")
 
 
-class PasswordChangeParityTest(RenderParityMixin, TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
+def test_changelist_filter(client, parity_superuser, parity_articles):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/article/?status__exact=published")
 
-    def setUp(self):
-        self.client.force_login(self.superuser)
 
-    def test_password_change(self):
-        self.assert_parity("/admin/password_change/")
+def test_changelist_boolean_filter(client, parity_superuser, parity_articles):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/article/?is_featured__exact=1")
+
+
+@pytest.fixture
+def parity_article(db):
+    cat = Category.objects.create(name="Science")
+    return Article.objects.create(
+        title="Parity Test",
+        slug="parity-test",
+        status="draft",
+        category=cat,
+        is_featured=True,
+        priority=5,
+    )
+
+
+def test_add_form(client, parity_superuser, parity_article):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/testapp/article/add/")
+
+
+def test_change_form(client, parity_superuser, parity_article):
+    client.force_login(parity_superuser)
+    assert_parity(client, f"/admin/testapp/article/{parity_article.pk}/change/")
+
+
+@pytest.fixture
+def article_to_delete_parity(db):
+    return Article.objects.create(title="Delete Me", slug="delete-me", status="draft")
+
+
+def test_delete_confirmation(client, parity_superuser, article_to_delete_parity):
+    client.force_login(parity_superuser)
+    assert_parity(client, f"/admin/testapp/article/{article_to_delete_parity.pk}/delete/")
+
+
+@pytest.fixture
+def article_for_history_parity(db):
+    return Article.objects.create(title="History Test", slug="history-test", status="draft")
+
+
+def test_history(client, parity_superuser, article_for_history_parity):
+    client.force_login(parity_superuser)
+    assert_parity(client, f"/admin/testapp/article/{article_for_history_parity.pk}/history/")
+
+
+def test_password_change(client, parity_superuser):
+    client.force_login(parity_superuser)
+    assert_parity(client, "/admin/password_change/")

--- a/tests/test_list_fields_mixin.py
+++ b/tests/test_list_fields_mixin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 from django.urls import resolve
 
 from django_admin_boost import admin
@@ -14,230 +14,263 @@ from django_admin_boost.mixins import ListFieldsMixin
 from tests.testapp.models import Article
 
 
-class _ChangelistTestBase(TestCase):
-    """Shared helpers for changelist mixin tests."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
-
-    def _changelist_request(self):
-        request = self.factory.get("/admin/testapp/article/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/")
-        return request
-
-    def _change_request(self, pk=1):
-        request = self.factory.get(f"/admin/testapp/article/{pk}/change/")
-        request.user = self.superuser
-        request.resolver_match = resolve(f"/admin/testapp/article/{pk}/change/")
-        return request
+@pytest.fixture
+def changelist_base(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    factory = RequestFactory()
+    site = admin.AdminSite()
+    return superuser, factory, site
 
 
-class TestListOnlyFields(_ChangelistTestBase):
-    """list_only_fields applies .only() with pk always included."""
-
-    def test_only_applied_on_changelist(self) -> None:
-        class Admin(ModelAdmin):
-            list_only_fields = ["title", "status"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert "id" in deferred_fields, "pk must always be included"
-        assert set(deferred_fields) == {"id", "title", "status"}
-
-    def test_pk_auto_included(self) -> None:
-        """Even if the user doesn't list pk, it's included."""
-
-        class Admin(ModelAdmin):
-            list_only_fields = ["title"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert "id" in deferred_fields
-
-    def test_empty_list_means_pk_only(self) -> None:
-        """list_only_fields = [] means .only(pk)."""
-
-        class Admin(ModelAdmin):
-            list_only_fields = []
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert set(deferred_fields) == {"id"}
-
-    def test_not_applied_on_change_view(self) -> None:
-        class Admin(ModelAdmin):
-            list_only_fields = ["title"]
-
-        article = Article.objects.create(title="Test")
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._change_request(article.pk))
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
+def _changelist_request(factory, superuser):
+    request = factory.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    return request
 
 
-class TestListDeferFields(_ChangelistTestBase):
-    """list_defer_fields applies .defer()."""
-
-    def test_defer_applied_on_changelist(self) -> None:
-        class Admin(ModelAdmin):
-            list_defer_fields = ["body", "slug"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert set(deferred_fields) == {"body", "slug"}
-
-    def test_empty_list_means_no_optimization(self) -> None:
-        """list_defer_fields = [] is the opt-out escape hatch."""
-
-        class Admin(ModelAdmin):
-            list_defer_fields = []
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
-
-    def test_not_applied_on_change_view(self) -> None:
-        class Admin(ModelAdmin):
-            list_defer_fields = ["body"]
-
-        article = Article.objects.create(title="Test")
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._change_request(article.pk))
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
+def _change_request(factory, superuser, pk=1):
+    request = factory.get(f"/admin/testapp/article/{pk}/change/")
+    request.user = superuser
+    request.resolver_match = resolve(f"/admin/testapp/article/{pk}/change/")
+    return request
 
 
-class TestMutualExclusivity(_ChangelistTestBase):
-    """Setting both list_only_fields and list_defer_fields raises an error."""
-
-    def test_both_set_raises_error(self) -> None:
-        class Admin(ModelAdmin):
-            list_only_fields = ["title"]
-            list_defer_fields = ["body"]
-
-        ma = Admin(Article, self.site)
-        with pytest.raises(ImproperlyConfigured, match="Cannot set both"):
-            ma.get_queryset(self._changelist_request())
-
-    def test_both_set_empty_raises_error(self) -> None:
-        """Even two empty lists conflict — the user must pick one."""
-
-        class Admin(ModelAdmin):
-            list_only_fields = []
-            list_defer_fields = []
-
-        ma = Admin(Article, self.site)
-        with pytest.raises(ImproperlyConfigured, match="Cannot set both"):
-            ma.get_queryset(self._changelist_request())
+# --- list_only_fields ---
 
 
-class TestAutoMode(_ChangelistTestBase):
-    """When neither attribute is set, auto mode resolves list_display to fields."""
+def test_only_applied_on_changelist(changelist_base):
+    superuser, factory, site = changelist_base
 
-    def test_auto_resolves_list_display_fields(self) -> None:
-        class Admin(ModelAdmin):
-            list_display = ["title", "status", "created_at"]
+    class Admin(ModelAdmin):
+        list_only_fields = ["title", "status"]
 
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert "id" in deferred_fields
-        assert set(deferred_fields) == {"id", "title", "status", "created_at"}
-
-    def test_auto_includes_pk(self) -> None:
-        class Admin(ModelAdmin):
-            list_display = ["title"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert "id" in deferred_fields
-
-    def test_auto_str_maps_to_pk(self) -> None:
-        """__str__ in list_display contributes only pk."""
-
-        class Admin(ModelAdmin):
-            list_display = ["__str__"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert set(deferred_fields) == {"id"}
-
-    def test_auto_skips_callables(self) -> None:
-        """Callables/methods that aren't concrete fields are ignored."""
-
-        class Admin(ModelAdmin):
-            list_display = ["title", "upper_title"]
-
-            def upper_title(self, obj):
-                return obj.title.upper()
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        # upper_title is a method, not a field — only title and pk
-        assert set(deferred_fields) == {"id", "title"}
-
-    def test_auto_not_applied_on_change_view(self) -> None:
-        class Admin(ModelAdmin):
-            list_display = ["title"]
-
-        article = Article.objects.create(title="Test")
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._change_request(article.pk))
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
-
-    def test_auto_handles_fk_field(self) -> None:
-        """A ForeignKey in list_display should include the _id column."""
-
-        class Admin(ModelAdmin):
-            list_display = ["title", "category"]
-
-        ma = Admin(Article, self.site)
-        qs = ma.get_queryset(self._changelist_request())
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert "category_id" in deferred_fields or "category" in deferred_fields
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert "id" in deferred_fields, "pk must always be included"
+    assert set(deferred_fields) == {"id", "title", "status"}
 
 
-class TestListFieldsMixinExport(_ChangelistTestBase):
-    """ListFieldsMixin is importable from the expected locations."""
+def test_pk_auto_included(changelist_base):
+    """Even if the user doesn't list pk, it's included."""
+    superuser, factory, site = changelist_base
 
-    def test_importable_from_mixins(self) -> None:
+    class Admin(ModelAdmin):
+        list_only_fields = ["title"]
 
-        assert ListFieldsMixin is not None
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert "id" in deferred_fields
 
-    def test_importable_from_top_level(self) -> None:
-        from django_admin_boost import ListFieldsMixin
 
-        assert ListFieldsMixin is not None
+def test_empty_list_means_pk_only(changelist_base):
+    """list_only_fields = [] means .only(pk)."""
+    superuser, factory, site = changelist_base
 
-    def test_importable_from_admin(self) -> None:
-        from django_admin_boost.admin import ListFieldsMixin
+    class Admin(ModelAdmin):
+        list_only_fields = []
 
-        assert ListFieldsMixin is not None
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert set(deferred_fields) == {"id"}
+
+
+def test_list_only_not_applied_on_change_view(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_only_fields = ["title"]
+
+    article = Article.objects.create(title="Test")
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_change_request(factory, superuser, article.pk))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+# --- list_defer_fields ---
+
+
+def test_defer_applied_on_changelist(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_defer_fields = ["body", "slug"]
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert set(deferred_fields) == {"body", "slug"}
+
+
+def test_defer_empty_list_means_no_optimization(changelist_base):
+    """list_defer_fields = [] is the opt-out escape hatch."""
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_defer_fields = []
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+def test_defer_not_applied_on_change_view(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_defer_fields = ["body"]
+
+    article = Article.objects.create(title="Test")
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_change_request(factory, superuser, article.pk))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+# --- Mutual exclusivity ---
+
+
+def test_both_set_raises_error(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_only_fields = ["title"]
+        list_defer_fields = ["body"]
+
+    ma = Admin(Article, site)
+    with pytest.raises(ImproperlyConfigured, match="Cannot set both"):
+        ma.get_queryset(_changelist_request(factory, superuser))
+
+
+def test_both_set_empty_raises_error(changelist_base):
+    """Even two empty lists conflict — the user must pick one."""
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_only_fields = []
+        list_defer_fields = []
+
+    ma = Admin(Article, site)
+    with pytest.raises(ImproperlyConfigured, match="Cannot set both"):
+        ma.get_queryset(_changelist_request(factory, superuser))
+
+
+# --- Auto mode ---
+
+
+def test_auto_resolves_list_display_fields(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["title", "status", "created_at"]
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert "id" in deferred_fields
+    assert set(deferred_fields) == {"id", "title", "status", "created_at"}
+
+
+def test_auto_includes_pk(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["title"]
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert "id" in deferred_fields
+
+
+def test_auto_str_maps_to_pk(changelist_base):
+    """__str__ in list_display contributes only pk."""
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["__str__"]
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert set(deferred_fields) == {"id"}
+
+
+def test_auto_skips_callables(changelist_base):
+    """Callables/methods that aren't concrete fields are ignored."""
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["title", "upper_title"]
+
+        def upper_title(self, obj):
+            return obj.title.upper()
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    # upper_title is a method, not a field — only title and pk
+    assert set(deferred_fields) == {"id", "title"}
+
+
+def test_auto_not_applied_on_change_view(changelist_base):
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["title"]
+
+    article = Article.objects.create(title="Test")
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_change_request(factory, superuser, article.pk))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+def test_auto_handles_fk_field(changelist_base):
+    """A ForeignKey in list_display should include the _id column."""
+    superuser, factory, site = changelist_base
+
+    class Admin(ModelAdmin):
+        list_display = ["title", "category"]
+
+    ma = Admin(Article, site)
+    qs = ma.get_queryset(_changelist_request(factory, superuser))
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert "category_id" in deferred_fields or "category" in deferred_fields
+
+
+# --- Import tests ---
+
+
+def test_importable_from_mixins():
+    assert ListFieldsMixin is not None
+
+
+def test_importable_from_top_level():
+    from django_admin_boost import ListFieldsMixin
+
+    assert ListFieldsMixin is not None
+
+
+def test_importable_from_admin():
+    from django_admin_boost.admin import ListFieldsMixin
+
+    assert ListFieldsMixin is not None

--- a/tests/test_list_only_fields.py
+++ b/tests/test_list_only_fields.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
 from django.contrib.auth.models import User
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory
 from django.urls import resolve
 
 from django_admin_boost import admin
@@ -11,143 +12,143 @@ from django_admin_boost.admin import ModelAdmin
 from tests.testapp.models import Article
 
 
-class ListOnlyFieldsChangelistTest(TestCase):
-    """Test that .only() is applied on changelist views."""
+@pytest.fixture
+def list_only_changelist_setup(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    factory = RequestFactory()
+    site = admin.AdminSite()
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
+    class TestArticleAdmin(ModelAdmin):
+        list_display = ["title", "status", "created_at"]
+        list_only_fields = ["id", "title", "status", "created_at"]
 
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
-
-        class TestArticleAdmin(ModelAdmin):
-            list_display = ["title", "status", "created_at"]
-            list_only_fields = ["id", "title", "status", "created_at"]
-
-        self.model_admin = TestArticleAdmin(Article, self.site)
-
-    def _make_changelist_request(self) -> object:
-        """Create a request that looks like a changelist request."""
-        request = self.factory.get("/admin/testapp/article/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/")
-        return request
-
-    def test_only_applied_on_changelist(self) -> None:
-        request = self._make_changelist_request()
-        qs = self.model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False, "Expected .only() to be applied (deferred_loading mode)"
-        assert set(deferred_fields) == {"id", "title", "status", "created_at"}
-
-    def test_queryset_still_works(self) -> None:
-        """Ensure the queryset actually executes without errors."""
-        Article.objects.create(title="Hello", status="published")
-        request = self._make_changelist_request()
-        qs = self.model_admin.get_queryset(request)
-        assert qs.count() == 1
-        article = qs.first()
-        assert article is not None
-        assert article.title == "Hello"
+    model_admin = TestArticleAdmin(Article, site)
+    return superuser, factory, model_admin
 
 
-class ListOnlyFieldsChangeViewTest(TestCase):
-    """Test that .only() is NOT applied on change views."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
-
-        class TestArticleAdmin(ModelAdmin):
-            list_only_fields = ["id", "title"]
-
-        self.model_admin = TestArticleAdmin(Article, self.site)
-
-    def test_only_not_applied_on_change_view(self) -> None:
-        article = Article.objects.create(title="Test")
-        request = self.factory.get(f"/admin/testapp/article/{article.pk}/change/")
-        request.user = self.superuser
-        request.resolver_match = resolve(f"/admin/testapp/article/{article.pk}/change/")
-        qs = self.model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
-
-    def test_only_not_applied_on_add_view(self) -> None:
-        request = self.factory.get("/admin/testapp/article/add/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/add/")
-        qs = self.model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
+def _make_changelist_request(factory, superuser):
+    request = factory.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    return request
 
 
-class ListOnlyFieldsOptOutTest(TestCase):
-    """Test that list_defer_fields=[] opts out of all optimization."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
-
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
-
-    def test_defer_empty_disables_optimization(self) -> None:
-        class PlainArticleAdmin(ModelAdmin):
-            list_defer_fields = []  # opt-out
-
-        model_admin = PlainArticleAdmin(Article, self.site)
-        request = self.factory.get("/admin/testapp/article/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/")
-        qs = model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is True
-        assert len(deferred_fields) == 0
-
-    def test_only_empty_means_pk_only(self) -> None:
-        class PkOnlyAdmin(ModelAdmin):
-            list_only_fields = []
-
-        model_admin = PkOnlyAdmin(Article, self.site)
-        request = self.factory.get("/admin/testapp/article/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/")
-        qs = model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert set(deferred_fields) == {"id"}
+def test_only_applied_on_changelist(list_only_changelist_setup):
+    superuser, factory, model_admin = list_only_changelist_setup
+    request = _make_changelist_request(factory, superuser)
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False, "Expected .only() to be applied (deferred_loading mode)"
+    assert set(deferred_fields) == {"id", "title", "status", "created_at"}
 
 
-class ListFieldsMixinStandaloneTest(TestCase):
-    """Test using the mixin directly with a custom ModelAdmin."""
+def test_queryset_still_works(list_only_changelist_setup):
+    """Ensure the queryset actually executes without errors."""
+    superuser, factory, model_admin = list_only_changelist_setup
+    Article.objects.create(title="Hello", status="published")
+    request = _make_changelist_request(factory, superuser)
+    qs = model_admin.get_queryset(request)
+    assert qs.count() == 1
+    article = qs.first()
+    assert article is not None
+    assert article.title == "Hello"
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.superuser = User.objects.create_superuser(username="admin", password="password")
 
-    def setUp(self) -> None:
-        self.factory = RequestFactory()
-        self.site = admin.AdminSite()
+@pytest.fixture
+def list_only_change_view_setup(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    factory = RequestFactory()
+    site = admin.AdminSite()
 
-        class CustomAdmin(ModelAdmin):
-            list_only_fields = ["id", "title", "status"]
+    class TestArticleAdmin(ModelAdmin):
+        list_only_fields = ["id", "title"]
 
-        self.model_admin = CustomAdmin(Article, self.site)
+    model_admin = TestArticleAdmin(Article, site)
+    return superuser, factory, model_admin
 
-    def test_mixin_works_with_plain_modeladmin(self) -> None:
-        request = self.factory.get("/admin/testapp/article/")
-        request.user = self.superuser
-        request.resolver_match = resolve("/admin/testapp/article/")
-        qs = self.model_admin.get_queryset(request)
-        deferred_fields, is_defer = qs.query.deferred_loading
-        assert is_defer is False
-        assert set(deferred_fields) == {"id", "title", "status"}
+
+def test_only_not_applied_on_change_view(list_only_change_view_setup):
+    superuser, factory, model_admin = list_only_change_view_setup
+    article = Article.objects.create(title="Test")
+    request = factory.get(f"/admin/testapp/article/{article.pk}/change/")
+    request.user = superuser
+    request.resolver_match = resolve(f"/admin/testapp/article/{article.pk}/change/")
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+def test_only_not_applied_on_add_view(list_only_change_view_setup):
+    superuser, factory, model_admin = list_only_change_view_setup
+    request = factory.get("/admin/testapp/article/add/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/add/")
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+@pytest.fixture
+def opt_out_setup(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    factory = RequestFactory()
+    site = admin.AdminSite()
+    return superuser, factory, site
+
+
+def test_defer_empty_disables_optimization(opt_out_setup):
+    superuser, factory, site = opt_out_setup
+
+    class PlainArticleAdmin(ModelAdmin):
+        list_defer_fields = []  # opt-out
+
+    model_admin = PlainArticleAdmin(Article, site)
+    request = factory.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is True
+    assert len(deferred_fields) == 0
+
+
+def test_only_empty_means_pk_only(opt_out_setup):
+    superuser, factory, site = opt_out_setup
+
+    class PkOnlyAdmin(ModelAdmin):
+        list_only_fields = []
+
+    model_admin = PkOnlyAdmin(Article, site)
+    request = factory.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert set(deferred_fields) == {"id"}
+
+
+@pytest.fixture
+def standalone_setup(db):
+    superuser = User.objects.create_superuser(username="admin", password="password")
+    factory = RequestFactory()
+    site = admin.AdminSite()
+
+    class CustomAdmin(ModelAdmin):
+        list_only_fields = ["id", "title", "status"]
+
+    model_admin = CustomAdmin(Article, site)
+    return superuser, factory, model_admin
+
+
+def test_mixin_works_with_plain_modeladmin(standalone_setup):
+    superuser, factory, model_admin = standalone_setup
+    request = factory.get("/admin/testapp/article/")
+    request.user = superuser
+    request.resolver_match = resolve("/admin/testapp/article/")
+    qs = model_admin.get_queryset(request)
+    deferred_fields, is_defer = qs.query.deferred_loading
+    assert is_defer is False
+    assert set(deferred_fields) == {"id", "title", "status"}


### PR DESCRIPTION
## Summary
Convert all test files from unittest.TestCase to pytest-django style (functions + fixtures).

Closes #21