### PR TITLE
feat: per-view query budget assertions for admin views

### DIFF
--- a/django_admin_boost/__init__.py
+++ b/django_admin_boost/__init__.py
@@ -6,9 +6,11 @@ For the full Jinja2-compatible admin replacement, use ``django_admin_boost.admin
 
 from django_admin_boost.mixins import ListFieldsMixin, SmartPaginatorMixin
 from django_admin_boost.paginators import EstimatedCountPaginator
+from django_admin_boost.query_budget import QueryBudgetMixin
 
 __all__ = [
     "EstimatedCountPaginator",
     "ListFieldsMixin",
+    "QueryBudgetMixin",
     "SmartPaginatorMixin",
 ]

--- a/django_admin_boost/query_budget.py
+++ b/django_admin_boost/query_budget.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+from django.db import connection, reset_queries
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponse
+
+logger = logging.getLogger(__name__)
+
+
+class QueryBudgetExceeded(Exception):  # noqa: N818
+    """Raised when a view exceeds its query budget."""
+
+    def __init__(self, budget: int, actual: int, queries: list[dict[str, str]]) -> None:
+        self.budget = budget
+        self.actual = actual
+        self.queries = queries
+        super().__init__(
+            f"Query budget exceeded: {actual} queries (budget: {budget})",
+        )
+
+
+class QueryBudgetMixin:
+    """ModelAdmin mixin that enforces a maximum query count on changelist views.
+
+    Only active when ``DEBUG=True``. Set ``query_budget`` on your ModelAdmin
+    to enforce a limit::
+
+        class MyAdmin(QueryBudgetMixin, admin.ModelAdmin):
+            query_budget = 10
+
+    When exceeded, raises ``QueryBudgetExceeded`` with the list of queries
+    for debugging. Set ``query_budget_warn_only = True`` to log a warning
+    instead of raising.
+    """
+
+    query_budget: int | None = None
+    query_budget_warn_only: bool = False
+
+    def changelist_view(
+        self,
+        request: HttpRequest,
+        extra_context: dict[str, Any] | None = None,
+    ) -> HttpResponse:
+        if not self._should_check_budget():
+            return super().changelist_view(request, extra_context=extra_context)  # type: ignore[misc]
+
+        reset_queries()
+        response = super().changelist_view(request, extra_context=extra_context)  # type: ignore[misc]
+        self._check_budget(connection.queries[:])
+        return response
+
+    def _should_check_budget(self) -> bool:
+        return self.query_budget is not None and settings.DEBUG
+
+    def _check_budget(self, queries: list[dict[str, str]]) -> None:
+        actual = len(queries)
+        if actual <= self.query_budget:  # type: ignore[operator]
+            return
+
+        if self.query_budget_warn_only:
+            logger.warning(
+                "Query budget exceeded for %s: %d queries (budget: %d)",
+                self.__class__.__name__,
+                actual,
+                self.query_budget,
+            )
+            return
+
+        raise QueryBudgetExceeded(self.query_budget, actual, queries)  # type: ignore[arg-type]

--- a/tests/test_query_budget.py
+++ b/tests/test_query_budget.py
@@ -1,0 +1,122 @@
+import importlib
+
+import pytest
+from django.contrib.admin import site as admin_site
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import clear_url_caches, set_urlconf
+
+from django_admin_boost.admin import ModelAdmin
+from django_admin_boost.query_budget import QueryBudgetExceeded, QueryBudgetMixin
+from tests.testapp.admin import ArticleAdmin
+from tests.testapp.models import Article
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser(username="admin", password="password")
+
+
+@pytest.fixture
+def articles(db):
+    return [Article.objects.create(title=f"Article {i}") for i in range(5)]
+
+
+def _register(model_admin_class):
+    """Register model_admin_class for Article and refresh URL patterns."""
+    if admin_site.is_registered(Article):
+        admin_site.unregister(Article)
+    admin_site.register(Article, model_admin_class)
+    _refresh_urls()
+
+
+def _restore():
+    """Restore ArticleAdmin and refresh URL patterns."""
+    if admin_site.is_registered(Article):
+        admin_site.unregister(Article)
+    admin_site.register(Article, ArticleAdmin)
+    _refresh_urls()
+
+
+def _refresh_urls():
+    """Force Django to rebuild URL patterns by reloading the URL conf module."""
+    import tests.settings.urls as url_module
+
+    importlib.reload(url_module)
+    clear_url_caches()
+    set_urlconf(None)
+
+
+@override_settings(DEBUG=True)
+def test_budget_exceeded_raises(client, superuser, articles):
+    class StrictAdmin(QueryBudgetMixin, ModelAdmin):
+        query_budget = 1  # impossibly low
+
+    _register(StrictAdmin)
+    try:
+        client.force_login(superuser)
+        with pytest.raises(QueryBudgetExceeded) as exc_info:
+            client.get("/admin/testapp/article/")
+        assert exc_info.value.actual > 1
+        assert exc_info.value.budget == 1
+        assert len(exc_info.value.queries) > 0
+    finally:
+        _restore()
+
+
+@override_settings(DEBUG=True)
+def test_budget_not_exceeded_passes(client, superuser, articles):
+    class RelaxedAdmin(QueryBudgetMixin, ModelAdmin):
+        query_budget = 100  # generous
+
+    _register(RelaxedAdmin)
+    try:
+        client.force_login(superuser)
+        response = client.get("/admin/testapp/article/")
+        assert response.status_code == 200
+    finally:
+        _restore()
+
+
+@override_settings(DEBUG=False)
+def test_budget_skipped_when_not_debug(client, superuser, articles):
+    class StrictAdmin(QueryBudgetMixin, ModelAdmin):
+        query_budget = 1
+
+    _register(StrictAdmin)
+    try:
+        client.force_login(superuser)
+        # Should not raise even with budget=1 because DEBUG=False
+        response = client.get("/admin/testapp/article/")
+        assert response.status_code == 200
+    finally:
+        _restore()
+
+
+@override_settings(DEBUG=True)
+def test_budget_warn_only_logs(client, superuser, articles, caplog):
+    class WarnAdmin(QueryBudgetMixin, ModelAdmin):
+        query_budget = 1
+        query_budget_warn_only = True
+
+    _register(WarnAdmin)
+    try:
+        client.force_login(superuser)
+        response = client.get("/admin/testapp/article/")
+        assert response.status_code == 200
+        assert "Query budget exceeded" in caplog.text
+    finally:
+        _restore()
+
+
+def test_no_budget_set_skips_check(client, superuser, articles):
+    class NobudgetAdmin(QueryBudgetMixin, ModelAdmin):
+        pass  # query_budget is None
+
+    _register(NobudgetAdmin)
+    try:
+        client.force_login(superuser)
+        response = client.get("/admin/testapp/article/")
+        assert response.status_code == 200
+    finally:
+        _restore()


### PR DESCRIPTION
## Summary
Add QueryBudgetMixin that enforces a maximum query count on admin changelist views. Only active when DEBUG=True. Raises QueryBudgetExceeded with the full query list for debugging, or logs a warning with query_budget_warn_only=True.

Closes #7